### PR TITLE
bugfix/fz-53: Changes scroll overflows to use auto

### DIFF
--- a/source/styleguide/example.css
+++ b/source/styleguide/example.css
@@ -67,7 +67,7 @@
 	border: 1px solid #ccc;
 	
 	padding: 1em;
-	overflow: scroll;
+	overflow: auto;
 
 	@media (width >= 960px) {
 		padding: 2em;

--- a/source/styleguide/nav.css
+++ b/source/styleguide/nav.css
@@ -80,7 +80,7 @@
 	height: 100vh;
 	width: 100%;
 	max-width: 320px;
-	overflow: scroll;
+	overflow: auto;
 
 	padding: 1em;
 	padding-top: 6em;

--- a/source/tags/page-root/page-root.css
+++ b/source/tags/page-root/page-root.css
@@ -25,10 +25,6 @@ code {
 	line-height: 1.4em;
 }
 
-pre {
-	/* overflow: scroll; */
-}
-
 button {
 	background-color: transparent;
 	font-size: 1em;


### PR DESCRIPTION
Example containers in styleguide were using `overflow:scroll;`  This results in always-visible scrollbars on Windows systems.  Changed rules to use `overflow:auto;` which will still permit scrolling overflow content but hides scrollbars when content does not overflow.

this resolves issue https://github.com/connectivedx/fuzzy-chainsaw/issues/53
