### PR TITLE
bugfix/fz-55: normalizes path delimiters to Unix style forward slash

### DIFF
--- a/source/render-page.jsx
+++ b/source/render-page.jsx
@@ -4,6 +4,6 @@ import Dom from 'react-dom/server';
 
 module.exports = function renderPage(locals, callback) {
 	const path = locals.path.substr(0, locals.path.length - 5);
-	const Page = require('./pages/' + path.replace(/\\/g, '/') + '.jsx').default;
+	const Page = require('./pages/' + path + '.jsx').default;
   callback(null, '<!DOCTYPE html>' + Dom.renderToStaticMarkup(<Page locals={locals} />, locals));
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,16 +13,19 @@ const getDeepName = source => blob => {
   const blobPath = path.resolve(__dirname, blob);
   const rootPath = path.resolve(__dirname, source);
   const name = blobPath.substr(rootPath.length + 1);
-  return name.substr(0, name.length - path.extname(blob).length);
+
+  return name
+    .substr(0, name.length - path.extname(blob).length)
+    .replace(/\\/g, '/');
 };
 
 
 // helpers for finding files for rendering
-const getDirectories = (src) => 
+const getDirectories = (src) =>
   fs.readdirSync(src)
     .filter(file => fs.statSync(path.join(src, file)).isDirectory());
 
-const componentExists = (baseSrc, name) => 
+const componentExists = (baseSrc, name) =>
   fileExists(path.resolve(baseSrc, name, name + '.jsx'));
 
 
@@ -31,14 +34,14 @@ const components =
   getDirectories('./source/components')
     .filter(name => componentExists('./source/components', name));
 
-const tags = 
+const tags =
   getDirectories('./source/tags')
     .filter(name => componentExists('./source/tags', name));
 
 
 // concatinate both lists together for the styleguide
 const prefix = pre => str => pre + str;
-const styleguides = 
+const styleguides =
   tags.map(prefix('tags/'))
     .concat(components.map(prefix('components/')))
 


### PR DESCRIPTION
edits path concatenation in render-page.jsx to replace Windows path delimiters (e.g., backslash) with Unix style forward slashes.

resolves issue https://github.com/connectivedx/fuzzy-chainsaw/issues/55
