### PR TITLE
Respect parameter defaults instead of hardcoding paths/devtools

### DIFF
--- a/build/webpack.browser.js
+++ b/build/webpack.browser.js
@@ -12,7 +12,7 @@ module.exports = ({
   outputScript = '/tmp/bundle.js',
   outputStyle = '/tmp/bundle.css',
 }) => ({
-  devServer: { 
+  devServer: {
     stats: 'errors-only'
   },
   devtool: devtool,
@@ -23,7 +23,7 @@ module.exports = ({
     path: outputPath,
     filename: outputScript
   },
-  publicPath: './dist/',
+  publicPath: publicPath,
   postcss: require('./postcss-pack.js'),
   module: {
     loaders: [

--- a/build/webpack.static.js
+++ b/build/webpack.static.js
@@ -15,10 +15,10 @@ module.exports = ({
   paths = [],
   locals = {}
 }) => ({
-  devServer: { 
+  devServer: {
     stats: 'errors-only'
   },
-  devtool: 'eval',
+  devtool: devtool,
   entry: {
     main: entry
   },
@@ -27,7 +27,7 @@ module.exports = ({
     filename: outputScript,
     libraryTarget: 'umd'
   },
-  publicPath: './dist/',
+  publicPath: publicPath,
   postcss: require('./postcss-pack.js'),
   module: {
     loaders: [


### PR DESCRIPTION
Chatted on Slack with @krambuhl about this yesterday. The webpack config factory should respect its parameters :)
