### PR TITLE
Modularize webpack error handler out of gulpfile

### DIFF
--- a/build/webpack-errorhandler.js
+++ b/build/webpack-errorhandler.js
@@ -1,0 +1,25 @@
+const chalk = require('chalk');
+
+module.exports = (err, stats, done) => {
+  if (err) return done(err);
+
+  let error = false;
+  stats.stats.forEach(build => {
+    if (build.compilation.errors && build.compilation.errors.length) {
+      build.compilation.errors.forEach(error => console.error(chalk.bgRed(error.toString())));
+      error = true;
+    }
+
+    if (build.compilation.warnings && build.compilation.warnings.length) {
+      build.compilation.warnings.forEach(warn => console.error(chalk.yellow(warn.toString())));
+    }
+  });
+
+  if(error) {
+    console.error('');
+    console.error(chalk.bgRed('Webpack completed with errors or warnings.'));
+    process.exit(1);
+  } else {
+    done();
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ const del = require('del')
 const webpackConfig = require('./webpack.config');
 const webpackProductionConfig = require('./webpack.production.config');
 const scaffoldComponent = require('./build/scaffold-component');
+const webpackErrorHandler = require('./build/webpack-errorhandler');
 
 // build tasks
 gulp.task('preClean', () => {
@@ -21,13 +22,13 @@ gulp.task('postClean', () => {
 
 gulp.task('buildWebpack', done => {
   webpack(webpackConfig, (err, stats) => {
-    reportWebpackErrors(err, stats, done);
+    webpackErrorHandler(err, stats, done);
   });
 })
 
 gulp.task('buildProductionWebpack', done => {
 	webpack(webpackProductionConfig, (err, stats) => {
-    reportWebpackErrors(err, stats, done);
+    webpackErrorHandler(err, stats, done);
   });
 });
 
@@ -39,29 +40,6 @@ gulp.task('production', done => {
   sequence('preClean', 'buildProductionWebpack', 'postClean', done);
 });
 
-const reportWebpackErrors = (err, stats, done) => {
-  if (err) return done(err);
-
-  let error = false;
-  stats.stats.forEach(build => {
-    if (build.compilation.errors && build.compilation.errors.length) {
-      build.compilation.errors.forEach(error => console.error(chalk.bgRed(error.toString())));
-      error = true;
-    }
-
-    if (build.compilation.warnings && build.compilation.warnings.length) {
-      build.compilation.warnings.forEach(warn => console.error(chalk.yellow(warn.toString())));
-    }
-  });
-
-  if(error) {
-    console.error('');
-    console.error(chalk.bgRed('Webpack completed with errors or warnings.'));
-    process.exit(1);
-  } else {
-    done();
-  }
-}
 
 
 // scaffolding tasks


### PR DESCRIPTION
Removes the webpack error handler from the gulpfile, as was discussed in an earlier ticket.

#MakeGulpfilesGreatAgain