### PR TITLE
Fixes watch issue where /dist did not exist

### DIFF
--- a/build/webpack-watch.js
+++ b/build/webpack-watch.js
@@ -14,8 +14,9 @@ module.exports = config => {
   // normalize config output paths
   // (code sniped from bin/webpack-dev-server.js:95)
   // without this, assets are not loaded correctly
-  [].concat(config).forEach(function(wpOpt) {
-    wpOpt.output.path = "/";
+  config = config.map(wpOpt => {
+    wpOpt.output.path = '/';
+    return wpOpt;
   });
 
   // watch function is called both
@@ -58,7 +59,7 @@ module.exports = config => {
     // see https://webpack.github.io/docs/webpack-dev-server.html#api for dev-server API options
     server = new WebpackDevServer(compiler, serverConfig);
 
-    server.listen(port, host, (err) => { 
+    server.listen(port, host, (err) => {
       var uri = "http://" + serverConfig.host + ":" + serverConfig.port + "/";
       if(!serverConfig.inline)
         uri += "webpack-dev-server/";

--- a/build/webpack-watch.js
+++ b/build/webpack-watch.js
@@ -1,4 +1,5 @@
 const chokidar = require('chokidar');
+const path = require('path');
 const webpack = require('webpack');
 const WebpackDevServer = require('webpack-dev-server');
 
@@ -10,6 +11,16 @@ let server;
 
 module.exports = config => {
 
+  // normalize config output paths
+  // (code sniped from bin/webpack-dev-server.js:95)
+  // without this, assets are not loaded correctly
+  [].concat(config).forEach(function(wpOpt) {
+    wpOpt.output.path = "/";
+  });
+
+  // watch function is called both
+  // (a) on startup and
+  // (b) when dirs are added or removed to recycle the watch and update static site file paths
   const watch = (changedPath) => {
     if(server && changedPath) {
       // stop the old dev server
@@ -28,22 +39,42 @@ module.exports = config => {
 
     var compiler = webpack(config);
 
-    // see https://webpack.github.io/docs/webpack-dev-server.html#api for dev-server API options
-    server = new WebpackDevServer(compiler, {
-      contentBase: pkg.directories.output,
-      filename: "bundle.js",
-      publicPath: "/",
+    const serverConfig = {
+      host: host,
+      port: port,
+      publicPath: '/',
+      outputPath: '/',
+      filename: '/tmp/[name].js',
+      contentBase: path.resolve(pkg.directories.output),
       hot: false,
       stats: {
         colors: true,
         chunks: false,
         hash: false,
-        timings: false,
         version: false
       }
-    });
+    };
 
-    server.listen(port, host, () => { console.log(`webpack-dev-server is now listening on http://${host}:${port}`); });
+    // see https://webpack.github.io/docs/webpack-dev-server.html#api for dev-server API options
+    server = new WebpackDevServer(compiler, serverConfig);
+
+    server.listen(port, host, (err) => { 
+      var uri = "http://" + serverConfig.host + ":" + serverConfig.port + "/";
+      if(!serverConfig.inline)
+        uri += "webpack-dev-server/";
+
+      if(err) throw err;
+
+      console.log(" " + uri);
+      console.log("webpack result is served from " + serverConfig.publicPath);
+
+      if(typeof serverConfig.contentBase === "object") {
+        console.log("requests are proxied to " + serverConfig.contentBase.target);
+      }
+      else {
+        console.log("content is served from " + serverConfig.contentBase);
+      }
+    });
   }
 
   chokidar.watch(pkg.directories.source, { ignoreInitial: true })


### PR DESCRIPTION
This is a resolution for #99. 

Specifically this block, taken from the `webpack-dev-server` bin script, is the fix:

https://github.com/connectivedx/fuzzy-chainsaw/blob/watch-fix/build/webpack-watch.js#L17

The rest is just additional logging to match the bin script.