### PR TITLE
fixes tabs issue in non-Blink browsers

### DIFF
--- a/source/styleguide.jsx
+++ b/source/styleguide.jsx
@@ -32,7 +32,8 @@ const examplesItems = examples.map(e => e.querySelectorAll('.sg-example__tabs-it
 
 examplesTabs.forEach((tabset, i) => {
 	tabset.addEventListener('click', ev => {
-		examplesItems[i].forEach((item, j) => {
+		Array.prototype.slice.call(examplesItems[i]).forEach((item, j) => {
+			console.log(examplesSections[i][j], item);
 			examplesItems[i][j].classList.toggle('is-active', item.contains(ev.target));
 			examplesSections[i][j].classList.toggle('is-active', item.contains(ev.target));
 		});

--- a/source/styleguide.jsx
+++ b/source/styleguide.jsx
@@ -33,7 +33,6 @@ const examplesItems = examples.map(e => e.querySelectorAll('.sg-example__tabs-it
 examplesTabs.forEach((tabset, i) => {
 	tabset.addEventListener('click', ev => {
 		Array.prototype.slice.call(examplesItems[i]).forEach((item, j) => {
-			console.log(examplesSections[i][j], item);
 			examplesItems[i][j].classList.toggle('is-active', item.contains(ev.target));
 			examplesSections[i][j].classList.toggle('is-active', item.contains(ev.target));
 		});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Please provide as much of the following information as possible -->
<!--- Feel free to delete whatever is not relevant to you -->

## Description
<!--- Describe your changes in detail -->
Tab switcher itterates over tabs and related content to set display classes on the affected tabs and content.  Elements were itterated in NodeLists using forEach(); this has not been implemented on NodeList in most browsers.
Fix was to call `Array.prototype.splice` on each NodeList before itteration.
Fixes #104 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Opened in affected browsers and verified I could switch tabs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

