### PR TITLE
Adding new crafted List tag

### DIFF
--- a/source/tags/List/List.css
+++ b/source/tags/List/List.css
@@ -1,0 +1,12 @@
+.list {
+
+}
+
+.list--indents--true {
+   margin-left: 15px; 	
+}
+
+.list--bullets--true {
+	list-style-type: disc; 
+	list-style-position: inside; 
+}

--- a/source/tags/List/List.jsx
+++ b/source/tags/List/List.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styles from './List.css';
+
+function parseItems(itemsData, tagName, indents, bullets){
+	let i, data, Tag, fragment, subFragment;
+	Tag = tagName;
+	fragment = [];
+	for(i = 0; i < itemsData.length; i++){
+		data = itemsData[i];
+		data.className = data.className || '';
+		if(data.subItems){
+			data.subClass = data.subClass || '--sub--list';
+			subFragment = parseItems(data.subItems, Tag, indents, bullets);
+			fragment.push(<li className={'item '+data.className}><a href={data.href}>{data.text}</a><Tag className={'sub-list list--indents--'+indents + ' list--bullets--'+bullets + ' ' + data.subClass}>{subFragment}</Tag></li>);
+		}else{
+			fragment.push(<li className={'item '+data.className}><a href={data.href}>{data.text}</a></li>);
+		}
+	}
+	return fragment;
+}
+
+export default ({
+	className = '',
+	children,
+	tagName = 'ul',
+	listData = [],
+	bullets = false,
+	indents = false
+}) => {
+	let Tag;
+	Tag = tagName;
+	if(listData.length) {
+		children = parseItems(listData, Tag, indents, bullets);
+	}
+	return (
+		<Tag className={'list ' + 'list--indents--'+indents + ' list--bullets--'+bullets + ' ' + className}>
+			{children}
+		</Tag>
+	)	
+}

--- a/source/tags/List/List.test.jsx
+++ b/source/tags/List/List.test.jsx
@@ -64,8 +64,8 @@ export default [{
 		<List tagName="ol" listData={ListData}></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ol'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ol'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 },{
@@ -74,8 +74,8 @@ export default [{
 		<List tagName="ul" listData={ListData}></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ul'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ul'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 },
@@ -85,8 +85,8 @@ export default [{
 		<List tagName="ol" listData={ListData} indents="true"></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ol'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ol'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 },{
@@ -95,8 +95,8 @@ export default [{
 		<List tagName="ul" listData={ListData} indents="true"></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ul'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ul'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 },
@@ -106,8 +106,8 @@ export default [{
 		<List tagName="ol" listData={ListData} indents="true" bullets="true"></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ol'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ol'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 },{
@@ -116,8 +116,8 @@ export default [{
 		<List tagName="ul" listData={ListData} indents="true" bullets="true"></List>
 	),
 	test(t, component) {
-		//t.equal(component.is('ul'), true, 'tag name');
-		//t.equal(component.is('.list'), true, 'tag class');
+		t.equal(component.is('ul'), true, 'tag name');
+		t.equal(component.is('.list'), true, 'tag class');
 		t.end();
 	}
 }];

--- a/source/tags/List/List.test.jsx
+++ b/source/tags/List/List.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import List from './List.jsx';
+
+let ListData = [
+	{
+		text: "List item one",
+		href: "/",
+		className: '--item--one',
+		subClass: '--list--sub--one',
+		subItems: [
+			{
+				text: "Sub item one",
+				href: "/",				
+			},
+			{
+				text: "Sub item two",
+				href: "/"
+			},
+			{
+				text: "Sub item three",
+				href: "/"
+			}						
+		]
+	},
+	{
+		text: "List item two",
+		href: "/",
+		className: '--item--two',
+		subClass: '--list--sub--one',
+		subItems: [
+			{
+				text: "Sub item one",
+				href: "/",
+				subClass: '--list--sub--two',
+				subItems: [
+					{
+						text: "Sub item one",
+						href: "/"
+					},
+					{
+						text: "Sub item two",
+						href: "/"
+					},
+					{
+						text: "Sub item three",
+						href: "/"
+					}						
+				]				
+			},
+			{
+				text: "Sub item two",
+				href: "/"
+			},
+			{
+				text: "Sub item three",
+				href: "/"
+			}						
+		]		
+	}
+];
+export default [{
+	name: "OL default",
+	component: (
+		<List tagName="ol" listData={ListData}></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ol'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+},{
+	name: "UL default",
+	component: (
+		<List tagName="ul" listData={ListData}></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ul'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+},
+{
+	name: "OL - indents",
+	component: (
+		<List tagName="ol" listData={ListData} indents="true"></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ol'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+},{
+	name: "UL - indents",
+	component: (
+		<List tagName="ul" listData={ListData} indents="true"></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ul'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+},
+{
+	name: "OL - indents & bullets",
+	component: (
+		<List tagName="ol" listData={ListData} indents="true" bullets="true"></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ol'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+},{
+	name: "UL - indents & bullets",
+	component: (
+		<List tagName="ul" listData={ListData} indents="true" bullets="true"></List>
+	),
+	test(t, component) {
+		//t.equal(component.is('ul'), true, 'tag name');
+		//t.equal(component.is('.list'), true, 'tag class');
+		t.end();
+	}
+}];

--- a/source/tags/List/README.md
+++ b/source/tags/List/README.md
@@ -6,3 +6,5 @@ Property | Function
 --- | ---
 `className` | Defines css className to add to the component's class list.
 `children` | Defines the children elements passed to the component.
+`indents` | Boolean - Turns indents on for full listing.
+`bullets` | Boolean - Turns bullets on for full listing.

--- a/source/tags/List/README.md
+++ b/source/tags/List/README.md
@@ -1,0 +1,8 @@
+# 
+
+## Props
+
+Property | Function
+--- | ---
+`className` | Defines css className to add to the component's class list.
+`children` | Defines the children elements passed to the component.

--- a/source/tags/List/README.md
+++ b/source/tags/List/README.md
@@ -6,5 +6,6 @@ Property | Function
 --- | ---
 `className` | Defines css className to add to the component's class list.
 `children` | Defines the children elements passed to the component.
+`listData` | Pass a data Object to tag for full children list item and sub list parsing.
 `indents` | Boolean - Turns indents on for full listing.
 `bullets` | Boolean - Turns bullets on for full listing.


### PR DESCRIPTION
Please review and comment on this newly created List tag.
Issue #92  has it listed as outstanding.

Allows you to build list items directly within in the tag's {children} like normal, or overload {children} with a data object for complex listings and sub listings. You can tagName attribute for ol or ul, turn indents and bullets on or off with indents and bullets attributes.

Thanks!