### PR TITLE
fixes misnamed import

### DIFF
--- a/source/variables/index.css
+++ b/source/variables/index.css
@@ -1,5 +1,5 @@
 @import "./custom-selectors.css";
 @import "./colors.css";
-@import "./typography.css";
+@import "./type.css";
 @import "./breakpoints.css";
 @import "./z-index.css";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
in variables/index.css, changed

`@import "./typography.css";` to `@import "./type.css";`

believe this may have resulted from a bad auto-merge of the file when #108 was merged.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

