### PR TITLE
improves appearance of tables and code in styleguide readme

### DIFF
--- a/source/styleguide/Styleguide.css
+++ b/source/styleguide/Styleguide.css
@@ -46,9 +46,39 @@
 
 .sg-styleguide-readme {
 	padding: 1em;
-	background-color: #eee;
+	background-color: gray(245);
 
 	@media (width >= 960px) {
 		padding: 2em;
+	}
+}
+
+.markdown {
+	& table {
+		border-collapse: collapse;
+		& * {
+			margin: 0;
+		}
+		&+ * {
+			margin-top: 2em;
+		}
+	}
+	& tr:nth-child(even) {
+		background-color: gray(230);
+	}
+	& th, & td {
+		border: 1px solid gray(200);
+		padding: .75em .5em;
+	}
+	& th {
+		font-weight: bold;
+	}
+
+	& code {
+		background-color: white;
+		border-radius: .125em .25em;
+		color: firebrick;
+		display: inline-block;
+		padding: .25em;
 	}
 }

--- a/source/styleguide/Styleguide.css
+++ b/source/styleguide/Styleguide.css
@@ -54,9 +54,11 @@
 
 	& table {
 		border-collapse: collapse;
+
 		& * {
 			margin: 0;
 		}
+
 		& + * {
 			margin-top: 2em;
 		}
@@ -66,7 +68,8 @@
 		background-color: gray(230);
 	}
 
-	& th, & td {
+	& th,
+	& td {
 		border: 1px solid gray(200);
 		padding: .75em .5em;
 	}

--- a/source/styleguide/Styleguide.css
+++ b/source/styleguide/Styleguide.css
@@ -51,25 +51,26 @@
 	@media (width >= 960px) {
 		padding: 2em;
 	}
-}
 
-.markdown {
 	& table {
 		border-collapse: collapse;
 		& * {
 			margin: 0;
 		}
-		&+ * {
+		& + * {
 			margin-top: 2em;
 		}
 	}
+
 	& tr:nth-child(even) {
 		background-color: gray(230);
 	}
+
 	& th, & td {
 		border: 1px solid gray(200);
 		padding: .75em .5em;
 	}
+
 	& th {
 		font-weight: bold;
 	}

--- a/source/tags/PageRoot/PageRoot.css
+++ b/source/tags/PageRoot/PageRoot.css
@@ -10,8 +10,7 @@ html {
 
 pre,
 code {
-	font-family: "PT Mono", mono;
-	font-size: 0.9em;
+	font-family: monospace;
 	line-height: 1.4em;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The readme is now appearing in the styleguide, however, the markdown CSS doesn't appear to be included in the styleguide.  for the most part, the elements in this section are styled by the `@extend`s on the rte container, however, `table` and `code` tags are a noticeable exception.  This change simply leverages the class on the readme container to target some styles to `<table>` and `<code>` in the readme.
