### PR TITLE
resolve paths for tap-min

### DIFF
--- a/webpack.factory.js
+++ b/webpack.factory.js
@@ -67,7 +67,7 @@ const configurationFactory = () => {
   const componentTests = testsConfig(baseOutput({
     entry: dirs.source + 'tests.jsx',
     outputScript: '/tmp/tests.js',
-    reporter: 'tap-min'
+    reporter: path.resolve(__dirname, 'node_modules', '.bin', 'tap-min')
   }));
 
   return [


### PR DESCRIPTION
This provides a – hopefully – cross platform fix to the tap-min issue described in #128.

## How'd I ding dang this doodle?

I tested this solution on my inferior mac machine, please check if this works on a windows dev machine.