### PR TITLE
Changes default webpack-dev-server host from localhost to 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Command | Description
 --- | ---
 `npm run build` | Compiles source files into output directory
 `npm run production` | Compiles and minifies source files into output directory.
-`npm run watch` | Compiles src directory and watches for file changes. Starts a development server at `http://localhost:8080`
+`npm run watch` | Compiles src directory and watches for file changes. Starts a development server at `http://0.0.0.0:8080` (also accessible at `http://localhost:8080`)
 `npm run start` | Starts a static server at `http://localhost:8080` to use with `npm run build`
 
 ### Scaffolding Tasks
@@ -34,5 +34,5 @@ It’s coming. Pinkie swear.
 GitHub gifted it to us as the randomly generated suggestion and we took it, because it’s a pretty awesome phrase.
 
 ### What verisons of Node are supported?
-Fuzzy Chainsaw was developed to work best with Node's [most recent LTS release](https://nodejs.org/en/download/) and up. At the time of this writing, LTS is 6.9.1. 
+Fuzzy Chainsaw was developed to work best with Node's [most recent LTS release](https://nodejs.org/en/download/) and up. At the time of this writing, LTS is 6.9.1.
 We intend to keep support pegged to Node's [LTS schedule](https://github.com/nodejs/LTS#lts-schedule).

--- a/build/webpack-watch.js
+++ b/build/webpack-watch.js
@@ -5,7 +5,7 @@ const WebpackDevServer = require('webpack-dev-server');
 const pkg = require('../package.json');
 
 module.exports = (configs, watchOpts) => {
-  watchOpts.host = watchOpts.host || 'localhost';
+  watchOpts.host = watchOpts.host || '0.0.0.0';
   watchOpts.port = watchOpts.port || 8080;
 
   // normalize config output paths


### PR DESCRIPTION
## Description
This commit changes the default host value passed into `webpack-watch` from `localhost` to `0.0.0.0`. Updates the corresponding documentation in the README as well.

## Motivation and Context
By default, `webpack-dev-server` is limited to _only_ serving on `localhost` (even without FC defaulting to `localhost` in `webpack-watch`, [as described in this issue](https://github.com/webpack/webpack-dev-server/issues/147)). So while running the `watch` task with the dev server on `localhost:8080`, you can’t then view the style guide at your machine’s IP address. Being able to do so is especially helpful when running builds on a VM and trying to access the site from the host environment (e.g.: running builds in a Windows VM, viewing on macOS). Per [the WebPack docs](https://webpack.github.io/docs/webpack-dev-server.html#webpack-dev-server-cli), setting the `host` option to `0.0.0.0` binds to all hosts. This allows you to hit your IP at the correct port from outside your local environment _or_ use `localhost:8080` locally to access your work. This, of course, works across local networks, so sharing your IP:8080 link will work with other team members both locally and on VPN.

## How Has This Been Tested?
* `npm run watch` on Windows 8.1 VM; successfully access resulting styleguide at `http://myvmipaddress:8080/` on macOS. Saved changes result in page refreshes in both environments as expected.

* `npm run watch` on macOS and successfully access resulting styleguide on Windows 8.1 VM. Saved changes result in page refreshes in both environments as expected.

* `npm run watch` on Windows 8.1 VM and successfully access resulting styleguide at `localhost:8080/` on the VM. Saved changes result in page refreshes as expected.

* `npm run watch` on Windows 8.1 VM and successfully access resulting styleguide at `http://myvmipaddress:8080/` over VPN.

* `npm run watch` on macOS and successfully access resulting styleguide at `http://myvmipaddress:8080/` on another machine on the local network.

* made a net -2 character change then wrote a PR novella like a jerk who just won't stop typing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

