### PR TITLE
Adds PlaceholderSvg tag

### DIFF
--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styles from './PlaceholderSvg.css';
+
+
+export const PlaceholderSvg = ({
+  width,
+  height,
+  text,
+  imgColor,
+  textColor,
+  fontFamily,
+  fontSize,
+  fontWeight
+}) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      <rect
+        fill={imgColor}
+        width="100%"
+        height="100%"
+      />
+      <text
+        fill={textColor}
+        fontFamily={fontFamily}
+        fontSize={fontSize}
+        fontWeight={fontWeight}
+        x='50%'
+        y='50%'
+        textAnchor='middle'>
+          {text}
+        </text>
+    </svg>
+  );
+}
+
+PlaceholderSvg.propTypes = {
+  width: React.PropTypes.number,
+  height: React.PropTypes.number,
+  text: React.PropTypes.string,
+  imgColor: React.PropTypes.string,
+  textColor: React.PropTypes.string,
+  fontFamily: React.PropTypes.string,
+  fontSize: React.PropTypes.string,
+  fontWeight: React.PropTypes.string
+};
+
+PlaceholderSvg.defaultProps = {
+  width: 500,
+  height: 250,
+  text: 'FPO',
+  imgColor: '#ccc',
+  textColor: '#fff',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+  fontWeight: 'bold'
+};
+
+export default PlaceholderSvg;

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -32,9 +32,10 @@ export const PlaceholderSvg = (props) => {
         fontWeight={fontWeight}
         x='50%'
         y='50%'
-        textAnchor='middle'>
-          {text}
-        </text>
+        textAnchor='middle'
+      >
+        {text}
+      </text>
     </svg>
   );
 }

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import styles from './PlaceholderSvg.css';
 
+export const PlaceholderSvg = (props) => {
+  const {
+    width,
+    height,
+    text,
+    imgColor,
+    textColor,
+    fontFamily,
+    fontSize,
+    fontWeight
+  } = props;
 
-export const PlaceholderSvg = ({
-  width,
-  height,
-  text,
-  imgColor,
-  textColor,
-  fontFamily,
-  fontSize,
-  fontWeight
-}) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -16,6 +16,8 @@ export const PlaceholderSvg = (props) => {
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox={`0 0 ${width} ${height}`}
+      width='100%'
+      style={{ maxWidth: '100%'}}
     >
       <rect
         fill={imgColor}

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './PlaceholderSvg.css';
 
 export const PlaceholderSvg = (props) => {
   const {

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -27,17 +27,17 @@ export const PlaceholderSvg = (props) => {
     >
       <rect
         fill={imgColor}
-        width='100%'
-        height='100%'
+        width="100%"
+        height="100%"
       />
       <text
         fill={textColor}
         fontFamily={fontFamily}
         fontSize={fontSize}
         fontWeight={fontWeight}
-        x='50%'
-        y='50%'
-        textAnchor='middle'
+        x="50%"
+        y="50%"
+        textAnchor="middle"
       >
         {text}
       </text>

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -41,8 +41,14 @@ export const PlaceholderSvg = (props) => {
 }
 
 PlaceholderSvg.propTypes = {
-  width: React.PropTypes.number,
-  height: React.PropTypes.number,
+  width: React.PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.string
+  ]),
+  height: React.PropTypes.oneOfType([
+    React.PropTypes.number,
+    React.PropTypes.string
+  ]),
   text: React.PropTypes.string,
   imgColor: React.PropTypes.string,
   textColor: React.PropTypes.string,

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -12,17 +12,23 @@ export const PlaceholderSvg = (props) => {
     fontWeight
   } = props;
 
+  const styles = {
+    height: `${height}px`,
+    maxWidth: '100%',
+    textTransform: 'uppercase',
+    width: `${width}px`
+  };
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox={`0 0 ${width} ${height}`}
-      width='100%'
-      style={{ maxWidth: '100%'}}
+      style={styles}
     >
       <rect
         fill={imgColor}
-        width="100%"
-        height="100%"
+        width='100%'
+        height='100%'
       />
       <text
         fill={textColor}

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.jsx
@@ -15,8 +15,6 @@ export const PlaceholderSvg = (props) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width={width}
-      height={height}
       viewBox={`0 0 ${width} ${height}`}
     >
       <rect

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
@@ -2,13 +2,33 @@ import React from 'react';
 import PlaceholderSvg from './PlaceholderSvg';
 
 export default [{
-  name: "default",
+  name: "Default",
   component: (
-    <PlaceholderSvg width={600} height='300' />
+    <PlaceholderSvg />
   ),
   test(t, component) {
     t.equal(component.is('svg'), true, 'tag name');
     t.equal(component.text(), 'FPO', 'text');
+    t.end();
+  }
+},
+{
+  name: "With all available props passed in",
+  component: (
+    <PlaceholderSvg
+      width={2000}
+      height='600'
+      fontSize='200%'
+      fontFamily='monospace'
+      fontWeight='normal'
+      imgColor='tomato'
+      textColor='bisque'
+      text='I’m an SVG!'
+    />
+  ),
+  test(t, component) {
+    t.equal(component.is('svg'), true, 'tag name');
+    t.equal(component.text(), 'I’m an SVG!', 'text');
     t.end();
   }
 }];

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import PlaceholderSvg from './PlaceholderSvg.jsx';
+import PlaceholderSvg from './PlaceholderSvg';
 
 export default [{
   name: "default",
   component: (
-    <PlaceholderSvg />
+    <PlaceholderSvg width={600} height='300' />
   ),
   test(t, component) {
     t.equal(component.is('svg'), true, 'tag name');

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
@@ -17,13 +17,13 @@ export default [{
   component: (
     <PlaceholderSvg
       width={2000}
-      height='600'
-      fontSize='200%'
-      fontFamily='monospace'
-      fontWeight='normal'
-      imgColor='tomato'
-      textColor='bisque'
-      text='I’m an SVG!'
+      height="600"
+      fontSize="200%"
+      fontFamily="monospace"
+      fontWeight="normal"
+      imgColor="tomato"
+      textColor="bisque"
+      text="I’m an SVG!"
     />
   ),
   test(t, component) {

--- a/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
+++ b/source/tags/PlaceholderSvg/PlaceholderSvg.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PlaceholderSvg from './PlaceholderSvg.jsx';
+
+export default [{
+  name: "default",
+  component: (
+    <PlaceholderSvg />
+  ),
+  test(t, component) {
+    t.equal(component.is('svg'), true, 'tag name');
+    t.equal(component.text(), 'FPO', 'text');
+    t.end();
+  }
+}];

--- a/source/tags/PlaceholderSvg/README.md
+++ b/source/tags/PlaceholderSvg/README.md
@@ -5,8 +5,8 @@ This component provides an easy way to build a placeholder SVG.
 
 Property | Default | Type | Function
 --- | --- | --- |:---
-`width` | `500` | Number | Defines the width of the SVG.
-`height` | `250` | Number | Defines the height of the SVG.
+`width` | `500` | Number or String | Defines the width of the SVG, in pixels. Must be a unitless value.
+`height` | `250` | Number or String | Defines the height of the SVG, in pixels. Must be a unitless value.
 `text` | `'FPO'` | String | The text displayed on the SVG.
 `imgColor` | `'#ccc'` | String | The color of the image. Can take any valid CSS color value.
 `textColor` | `'#fff'` | String | The color of the text displayed on the SVG. Can take any valid CSS color value.

--- a/source/tags/PlaceholderSvg/README.md
+++ b/source/tags/PlaceholderSvg/README.md
@@ -1,0 +1,15 @@
+# PlaceholderSvg
+This component provides an easy way to build a placeholder SVG.
+
+## Props
+
+Property | Default | Type | Function
+--- | --- | --- |:---
+`width` | `500` | Number | Defines the width of the SVG.
+`height` | `250` | Number | Defines the height of the SVG.
+`text` | `'FPO'` | String | The text displayed on the SVG.
+`imgColor` | `'#ccc'` | String | The color of the image. Can take any valid CSS color value.
+`textColor` | `'#fff'` | String | The color of the text displayed on the SVG. Can take any valid CSS color value.
+`fontFamily` | `'inherit'` | String | The display `font-family` for the `text`.
+`fontSize` | `'inherit'` | String | The display `font-size` for the `text`.
+`fontWeight` | `'bold'` | String | The display `font-weight` for the `text`.


### PR DESCRIPTION
## Description
Adds a new PlaceholderSvg tag for building placeholder/FPO images using an SVG.

## Motivation and Context
[FPO Image](http://fpoimg.com/) or [Fill Murray](http://www.fillmurray.com/) only get us so far and can be slow. This provides an easy and composable alternative by building an inline SVG with a bunch of display options.

## How Has This Been Tested?
I used it. I wrote a simple test. That's about it.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
