### PR TITLE
Updates meta tags in Skeleton_Head

### DIFF
--- a/source/tags/Skeleton/Skeleton.jsx
+++ b/source/tags/Skeleton/Skeleton.jsx
@@ -19,7 +19,6 @@ export const Skeleton_Head = ({
   <head>
     <meta charSet="utf-8" />
     <title>{title}</title>
-    <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     {children}

--- a/source/tags/Skeleton/Skeleton.jsx
+++ b/source/tags/Skeleton/Skeleton.jsx
@@ -17,8 +17,10 @@ export const Skeleton_Head = ({
   children
 }) => (
   <head>
-    <meta charset="utf-8" />
+    <meta charSet="utf-8" />
     <title>{title}</title>
+    <meta httpEquiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/assets/styles.css" />
     {children}
   </head>


### PR DESCRIPTION
## Description
In `Skeleton_Head`:
* adds `<meta name="viewport" content="width=device-width, initial-scale=1.0" />` to make responsive pages actually behave responsively
* updates the `charset=“utf-8”` attribute to the camelCased JSX-friendly `charSet`

## Motivation and Context
Looked at a page on my phone and noticed it isn't responsive, so added the `viewport` tag. Then I remembered #127 and updated the charset attribute since I was in there. :dancers: 

(Apologies if these are already in other branches; they're not on dev so I went for it.)

## How Has This Been Tested?
Attributes now showing in the HTML tab on Skeleton's test page and pages load responsively on my phone.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
