### PR TITLE
Fixes propType check for Rhythm ‘deep’ prop

### DIFF
--- a/source/tags/Rhythm/Rhythm.jsx
+++ b/source/tags/Rhythm/Rhythm.jsx
@@ -25,7 +25,7 @@ Rhythm.propTypes = {
   size: React.PropTypes.string,
   deep: React.PropTypes.oneOfType([
     React.PropTypes.string,
-    React.PropTypes.boolean
+    React.PropTypes.bool
   ])
 };
 


### PR DESCRIPTION
## Description
Fixes a typo in `Rhythm` tag proptypes check from `PropTypes.boolean` to`PropTypes.bool`.

## Motivation and Context
Typos begat type fixes! (I dunno. ¯\\_(ツ)_/¯ )

## How Has This Been Tested?
Vigorously

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
