### PR TITLE
Adds integration watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Command | Description
 `npm run build` | Compiles source files into output directory
 `npm run production` | Compiles and minifies source files into output directory.
 `npm run watch` | Compiles src directory and watches for file changes. Starts a development server at `http://0.0.0.0:8080` (also accessible at `http://localhost:8080`)
+`npm run integration-watch` | Compiles src directory into output directory and watches for file changes.
 `npm run start` | Starts a static server at `http://localhost:8080` to use with `npm run build`
 
 ### Scaffolding tasks

--- a/build/webpack-watch-integration.js
+++ b/build/webpack-watch-integration.js
@@ -1,0 +1,9 @@
+const webpack = require('webpack');
+const webpackErrorHandler = require('./webpack/lib/webpack-errorhandler');
+const config = require('./webpack/webpack.config');
+
+module.exports = done => {
+  webpack(config).watch({ }, (err, stats) => {
+    webpackErrorHandler(err, stats, {}, () => { });
+  });
+}

--- a/build/webpack-watch-integration.js
+++ b/build/webpack-watch-integration.js
@@ -4,6 +4,6 @@ const config = require('./webpack/webpack.config');
 
 module.exports = done => {
   webpack(config).watch({ }, (err, stats) => {
-    webpackErrorHandler(err, stats, {}, () => { });
+    webpackErrorHandler(err, stats, { noexit: true }, () => { });
   });
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ gulp.task('clean:post', require('./build/clean-post'));
 gulp.task('webpack:build', require('./build/webpack-build'));
 gulp.task('webpack:production', require('./build/webpack-production'));
 gulp.task('webpack:watch', require('./build/webpack-watch'));
+gulp.task('webpack:watch:integration', require('./build/webpack-watch-integration'));
 
 
 // define workflows
@@ -21,6 +22,10 @@ gulp.task('production', done => {
 
 gulp.task('watch', done => {
   sequence('clean:pre', 'webpack:watch', done);
+});
+
+gulp.task('watch:integration', done => {
+  sequence('clean:pre', 'webpack:watch:integration', done);
 });
 
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "build": "gulp build",
     "production": "gulp production",
     "watch": "gulp watch",
+    "integration-watch": "gulp watch:integration",
     "new-tag": "gulp scaffold:tag --name",
     "new-component": "gulp scaffold:component --name",
     "webpack-build": "webpack --config ./build/webpack/webpack.config.js --progress",
-    "webpack-watch": "webpack-dev-server --config ./build/webpack/webpack.config.js"
+    "webpack-watch": "webpack-dev-server --config ./build/webpack/webpack.config.js --progress"
   },
   "engines": {
     "node": "^=6.9.2"


### PR DESCRIPTION
## Description

Adds `npm run integration-watch` for use in integration environments, where one might want to see file changes in the os filesystem instead of the webpack-dev-server's virtual filestyle.

## Motivation and Context

#150 

## How Has This Been Tested?

This has been run on a mac machine, needs a windows test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)