### PR TITLE
production css custom selector errors

### DIFF
--- a/build/webpack/webpack.production.config.js
+++ b/build/webpack/webpack.production.config.js
@@ -5,13 +5,14 @@
   tasks such as minification to enabled. Thus, changes to the debug build also apply here unless
   this configuration actively undoes them.
 */
-const cssnano = require('cssnano');
 const webpack = require('webpack');
+const PostCssPipelineWebpackPlugin = require('postcss-pipeline-webpack-plugin');
+
 let build = require('./webpack.factory')();
 
 // production specific configuration
 module.exports = build.map(config => {
-  if(config.doNotApplyProductionConfig) {
+  if (config.workflow === 'test') {
     return config;
   }
 
@@ -28,20 +29,27 @@ module.exports = build.map(config => {
     })
   );
 
+  // add css minification
+  if (config.workflow === 'browser') {
+    config.plugins.push(
+      new PostCssPipelineWebpackPlugin({
+        suffix: undefined,
+        pipeline: [
+          require('cssnano')
+        ]
+      })
+    );
+  }
+
   // uglify JS
-  config.plugins.push(new webpack.optimize.UglifyJsPlugin({
-    sourceMap: false,
+  config.plugins.push(
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: false,
       compress: {
         warnings: false
       }
-  }));
-
-  // add css minification
-  if (config.postcss !== undefined) {
-    config.postcss = config.postcss.concat([
-      cssnano()
-    ]);
-  }
+    })
+  );
 
   return config;
 });

--- a/build/webpack/workflow/webpack.browser.js
+++ b/build/webpack/workflow/webpack.browser.js
@@ -31,11 +31,12 @@ module.exports = ({
       outputScript
     }),
     {
+      workflow: 'browser',
       module: {
         loaders: [
           {
             test: /\.css$/,
-            loader: ExtractTextPlugin.extract('css?sourceMap')
+            loader: ExtractTextPlugin.extract('css?-minimize&sourceMap')
           },
           {
             test: /\.(jpe?g|png|gif|svg)$/i,

--- a/build/webpack/workflow/webpack.static.js
+++ b/build/webpack/workflow/webpack.static.js
@@ -29,6 +29,7 @@ module.exports = ({
       outputScript
     }),
     {
+      workflow: 'static',
       output: {
         libraryTarget: 'umd'
       },

--- a/build/webpack/workflow/webpack.tests.js
+++ b/build/webpack/workflow/webpack.tests.js
@@ -26,6 +26,7 @@ module.exports = ({
       outputScript
     }),
     {
+      workflow: 'test',
       target: 'node',
       node: {
         fs: 'empty'
@@ -45,8 +46,7 @@ module.exports = ({
       },
       plugins: [
         new TapWebpackPlugin({ reporter: reporter })
-      ],
-      doNotApplyProductionConfig: true
+      ]
     }
   );
 }


### PR DESCRIPTION
## Description

Makes changes to webpack build files to skip minimizing css files through JsUglify, which was causing custom pseudo-selectors to mysteriously not expand.

This also now properly minimizes css, which was not actually happening before because of our css architecture.

## Motivation and Context

#157 

## How Has This Been Tested?

1. run `npm run production`
2. check `/dist/assets/styles.css`
3. should see `.button--default:hover, .button--default:active` instead of `.button--default:--enter`

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Update Instructions

- replace project `/build/webpack` folder with FC's `/build/webpack` folder