### PR TITLE
Styleguide syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
+    "react-syntax-highlighter": "^4.0.1",
     "reset-css": "^2.2.0",
     "run-sequence": "^1.2.2",
     "slug": "^0.9.1",

--- a/source/styleguide/tags/Example/Example.jsx
+++ b/source/styleguide/tags/Example/Example.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import Dom from 'react-dom/server';
 import { pd } from 'pretty-data';
 
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { github } from 'react-syntax-highlighter/dist/styles';
+
 import Heading from '../Heading/Heading';
 
 const json2htmlAttrs = obj =>
@@ -96,19 +99,25 @@ export default ({
 
       <ExampleSection title="React" type="react" slug={slug}>
         <pre><code>
-          { pd.xml(reactExample) }
+          <SyntaxHighlighter lanaguage="javascript" style={github} customStyle={{backgroundColor:'transparent'}}>
+            { pd.xml(reactExample) }
+          </SyntaxHighlighter>
         </code></pre>
       </ExampleSection>
 
       <ExampleSection title="HTML" type="html" slug={slug}>
         <pre><code>
-          { pd.xml(htmlExample) }
+          <SyntaxHighlighter lanaguage="html" style={github} customStyle={{backgroundColor:'transparent'}}>
+            { pd.xml(htmlExample) }
+          </SyntaxHighlighter>
         </code></pre>
       </ExampleSection>
 
       <ExampleSection title="JSON" type="json" slug={slug}>
         <pre><code>
+          <SyntaxHighlighter lanaguage="json" style={github} customStyle={{backgroundColor:'transparent'}}>
           { jsonExample }
+          </SyntaxHighlighter>
         </code></pre>
       </ExampleSection>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,6 +2581,14 @@ he@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
 
+highlight.js@~9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.8.0.tgz#38eeef40cd45eaddbec8c9e5238fb7a783a3b685"
+
+highlight.js@~9.9.0:
+  version "9.9.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.9.0.tgz#b9995dcfdc2773e307a34f0460d92b9a474782c0"
+
 hirestime@^1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/hirestime/-/hirestime-1.0.7.tgz#2d5271ea84356cec3f25da8c56a9402f8fc0a700"
@@ -3420,7 +3428,7 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
-lodash.isempty@^4.2.1, lodash.isempty@^4.4.0:
+lodash.isempty@^4.2.1:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
@@ -3583,6 +3591,12 @@ lower-case@^1.1.1:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lowlight@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.6.0.tgz#92f61e31e09ae9e971e70cabdd9e8f219f025232"
+  dependencies:
+    highlight.js "~9.9.0"
 
 lpad-align@^1.0.1:
   version "1.1.0"
@@ -4919,6 +4933,14 @@ react-dom@^15.3.2:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-syntax-highlighter@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-4.0.1.tgz#c14bed958d0a98ed805b8695129dd4767a1bd419"
+  dependencies:
+    babel-runtime "^6.18.0"
+    highlight.js "~9.8.0"
+    lowlight "^1.5.0"
 
 react@^15.3.2:
   version "15.4.1"


### PR DESCRIPTION
## Description

Adds syntax highlighting to styleguide examples.

## Upgrade Instructions

- Add `react-syntax-highlighter` to project `package.json`
- Replace project `/source/styleguide/tags/Example/Example.jsx` file with FC equivalent. 

## Motivation and Context

Fixes #156 

## How Has This Been Tested?

This has been tested using `npm run build` and `npm run watch`.  

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
