### PR TITLE
Optimize webpack browser build

### DIFF
--- a/build/clean-post.js
+++ b/build/clean-post.js
@@ -5,5 +5,11 @@ const pkg = require(path.resolve(pkgpath.self(), 'package.json'));
 const dirs = pkg.directories;
 
 module.exports = () => {
-  return del(path.resolve(pkgpath.self(), dirs.dest, 'tmp'), { force: true })
+  return del([
+    path.resolve(pkgpath.self(), dirs.dest, 'tmp'),
+    path.resolve(pkgpath.self(), dirs.dest, 'assets/scripts.css'),
+    path.resolve(pkgpath.self(), dirs.dest, 'assets/scripts.css.map'),
+    path.resolve(pkgpath.self(), dirs.dest, 'assets/styles.js'),
+    path.resolve(pkgpath.self(), dirs.dest, 'assets/styles.js.map'),
+  ], { force: true })
 };

--- a/build/webpack/webpack.factory.js
+++ b/build/webpack/webpack.factory.js
@@ -49,24 +49,18 @@ const baseOutput = config => Object.assign({
 const configurationFactory = () => {
   const renderStatic = staticConfig(baseOutput({
     entry: {
-      styleguide: path.resolve(dirs.source, 'RenderStatic.jsx')
+      static: path.resolve(dirs.source, 'RenderStatic.jsx')
     }
   }));
 
-  const styleguideBundle = browserConfig(baseOutput({
-    entry: path.resolve(dirs.source, 'styleguide/styleguide.jsx'),
-    outputScript: '/assets/styleguide.js',
-    outputStyle: '/assets/styleguide.css'
-  }));
-
-  const browserStyles = browserConfig(baseOutput({
-    entry: path.resolve(dirs.source, 'styles.jsx'),
-    outputStyle: '/assets/styles.css'
-  }));
-
-  const browserScripts = browserConfig(baseOutput({
-    entry: path.resolve(dirs.source, 'scripts.jsx'),
-    outputScript: '/assets/scripts.js',
+  const browserBundles = browserConfig(baseOutput({
+    entry: {
+      styleguide: path.resolve(dirs.source, 'styleguide/styleguide.jsx'),
+      styles: path.resolve(dirs.source, 'styles.jsx'),
+      scripts: path.resolve(dirs.source, 'scripts.jsx')
+    },
+    outputScript: '/assets/[name].js',
+    outputStyle: '/assets/[name].css'
   }));
 
   const componentTests = testsConfig(baseOutput({
@@ -77,9 +71,7 @@ const configurationFactory = () => {
 
   return [
     renderStatic,
-    styleguideBundle,
-    browserStyles,
-    browserScripts,
+    browserBundles,
     componentTests
   ];
 };


### PR DESCRIPTION
## Description

Updates the webpack factory to compress the 3 browser workflow configs into a single config.  This doesn't really improve speed of builds, but is a stepping stone to 1.1

## Motivation and Context

less repetitive code is good.

## How Has This Been Tested?

🙄 🖥 🏁 

- `npm run build`
- `npm run production`
- `npm run watch`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
