### PR TITLE
Fixes IconSet pathing

### DIFF
--- a/source/tags/Icon/IconSet.js
+++ b/source/tags/Icon/IconSet.js
@@ -1,2 +1,28 @@
+const getAssetPath = () => {
+  // get an element that references assets
+  const el = document.querySelector('[src*="assets/"]')
+
+  // get the prefix of the asset path
+  if (el) {
+    const src = el.getAttribute('src')
+    const prefix = src.substr(0, src.indexOf('assets/'))
+    return prefix;
+  }
+
+  return undefined;
+}
+
+// store orginal baseUrl
+const originalBaseUrl = global.baseUrl;
+
+// set the baseUrl for svgstore
+global.baseUrl = getAssetPath();
+
+// require icons
 const __svg__ = { path: './assets/**/*.svg', name: '/assets/svgs/iconset.svg' };
 require('webpack-svgstore-plugin/src/helpers/svgxhr')(__svg__);
+
+// restore the original baseUrl
+if (originalBaseUrl) {
+  window.baseUrl = originalBaseUrl;
+}

--- a/source/tags/Icon/IconSet.js
+++ b/source/tags/Icon/IconSet.js
@@ -1,11 +1,11 @@
 const getAssetPath = () => {
   // get an element that references assets
-  const el = document.querySelector('[src*="assets/"]')
+  const el = document.querySelector('[src*="assets/scripts.js"]')
 
   // get the prefix of the asset path
   if (el) {
     const src = el.getAttribute('src')
-    const prefix = src.substr(0, src.indexOf('assets/'))
+    const prefix = src.substr(0, src.indexOf('assets/scripts.js'))
     return prefix;
   }
 


### PR DESCRIPTION
## Description

This fixes an error with IconSet pathing.  This extracts the relative file prefix `../../..` from another `<script>` tag that references `/assets` on page and uses that as the plugin baseUrl.

## Motivation and Context

#168 

It was previously an absolute path, and would not work when the root is on a deep path.

## How Has This Been Tested?

Tested `build`, `production`, `watch` on a local url and verified on UI server with @pgregorova 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)