### PR TITLE
Replaces slug dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "reset-css": "^2.2.0",
     "responsive-loader": "^0.7.0",
     "run-sequence": "^1.2.2",
-    "slug": "^0.9.1",
+    "slugify": "^1.1.0",
     "static-generator-webpack-plugin": "^3.1.2",
     "svg-as-symbol-loader": "^1.1.3",
     "tap-min": "^1.1.0",

--- a/source/styleguide/components/Styleguide/Styleguide.jsx
+++ b/source/styleguide/components/Styleguide/Styleguide.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import slug from 'slug';
+import slugify from 'slugify';
 
 import Heading from '../../tags/Heading/Heading';
 import Skeleton from '../../tags/Skeleton/Skeleton';
 import Example from '../../tags/Example/Example';
 import Rhythm from '../../tags/Rhythm/Rhythm';
 
-slug.charmap['/'] = '-';
 
 export const Styleguide_Readme = ({ readme }) => (
   <div id="readme" className="sg-styleguide__section">
@@ -47,9 +46,9 @@ export const Styleguide_Tests = ({ tests, options }) => (
           .filter(e => !(e.options && e.options.hidden))
           .map((e, i) =>
             <div key={i}><a
-              href={'#' + slug(e.name)}
-              key={slug(e.name)}
-              value={slug(e.name)}>{e.name}</a></div>) }
+              href={'#' + slugify(e.name)}
+              key={slugify(e.name)}
+              value={slugify(e.name)}>{e.name}</a></div>) }
       </Rhythm>
     </Rhythm>
 
@@ -57,8 +56,8 @@ export const Styleguide_Tests = ({ tests, options }) => (
       .filter(e => !(e.options && e.options.hidden))
       .map(e =>
         <Example
-          key={slug(e.name)}
-          slug={slug(e.name)}
+          key={slugify(e.name)}
+          slug={slugify(e.name)}
           tagName={e.name}
           exampleName={e.name}
           component={e.component}

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,22 +872,6 @@ buffer@^4.9.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-"bufferjs@>= 2.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bufferjs/-/bufferjs-3.0.1.tgz#0692e829cb10a10550e647390b035eb06c38e8ef"
-
-"bufferstream@>= 0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/bufferstream/-/bufferstream-0.6.2.tgz#a5f27e10d3c760084d14b35126615007319e3731"
-  dependencies:
-    bufferjs ">= 2.0.0"
-  optionalDependencies:
-    buffertools ">= 1.0.3"
-
-"buffertools@>= 1.0.3":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/buffertools/-/buffertools-2.1.4.tgz#62d4e1584c0090a0c7d3587f25934a84b8b38de4"
-
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -5670,11 +5654,9 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slug@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
-  dependencies:
-    unicode ">= 0.3.1"
+slugify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.1.0.tgz#7e5b0938d52b5efab1878247ef0f6a4f05db7ee0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -6248,12 +6230,6 @@ uid-number@~0.0.6:
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "http://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
-
-"unicode@>= 0.3.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-0.6.1.tgz#ec69e3c4537e2b9650b826133bcb068f0445d0bc"
-  dependencies:
-    bufferstream ">= 0.6.2"
 
 union@~0.4.3:
   version "0.4.6"


### PR DESCRIPTION
## Description

This replaces the `slug` module with `slugify`, which does not have locale dependencies.

## Motivation and Context

Linking languages in npm/yarn is slow. 

## How Has This Been Tested?

`build`, `production`, and `watch` with success.

## Types of changes
- [X] Breaking change (fix or feature that would cause existing functionality to change)
