### PR TITLE
Adds a file hash to the iconset svg

### DIFF
--- a/source/tags/Icon/IconSet.js
+++ b/source/tags/Icon/IconSet.js
@@ -1,2 +1,2 @@
-const __svg__ = { path: './assets/**/*.svg', name: '/assets/svgs/iconset.svg' };
+const __svg__ = { path: './assets/**/*.svg', name: '/assets/svgs/iconset-[hash].svg' };
 require('webpack-svgstore-plugin/src/helpers/svgxhr')(__svg__);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Please provide as much of the following information as possible -->
<!--- Feel free to delete whatever is not relevant to you -->

## Description
Adds a file hash to the iconset svg for cache busting.

The async loader automatically uses the hash name so this works without HTML alterations, at least in my testing.

## Motivation and Context

Allows long caching to be set for SVGs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)