### PR TITLE
comment out react-model for windows machines

### DIFF
--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -18,7 +18,7 @@ module.exports.dlls = {
     'react',
     'react-dom/server',
     'prop-types',
-    'react-modal',
+    // 'react-modal', // failing on windows build in DLL
     'minimatch',
     'pretty',
     'prismjs',


### PR DESCRIPTION
- removes `react-modal` from styleguide DLL