### PR TITLE
2.0.1/bug/remove-postcss-fc-config

### DIFF
--- a/build/webpack/lib/postcss-plugins.js
+++ b/build/webpack/lib/postcss-plugins.js
@@ -32,8 +32,6 @@ const CachedInputFileSystem = require('enhanced-resolve/lib/CachedInputFileSyste
 const { source } = require('../../lib/path-helpers');
 const { resolve } = require('../workflow/shared');
 
-const { postcssPlugins } = require(source('fc-config')); // eslint-disable-line
-
 
 const fileSystem = new CachedInputFileSystem(new NodeJsInputFileSystem(), 60000);
 const resolver = ResolverFactory.createResolver({
@@ -59,7 +57,6 @@ const standard = [
     }
   }),
   extend(),
-  ...postcssPlugins.build,
   discardEmpty(),
   removeRoot()
 ];
@@ -88,6 +85,5 @@ module.exports.build = [
 
 
 module.exports.production = [
-  ...postcssPlugins.production,
   cssnano()
 ];

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -84,10 +84,3 @@ module.exports.themes = [{
   id: 'generic',
   name: 'Generic'
 }];
-
-// define additional postcss plugins to
-// add to the standard plugins
-module.exports.postcssPlugins = {
-  build: [],
-  production: []
-};


### PR DESCRIPTION
remove postcss plugins from fc config because it can be sucked up into webpack and cause critical dependencies (will revisit postcss config in a 2.x type release).