### PR TITLE
2.0.1/styleguide anchor identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,9 +129,9 @@
     "pretty": "^2.0.0",
     "pretty-data": "^0.40.0",
     "prop-types": "^15.5.10",
+    "rand-token": "^0.3.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-element-to-jsx-string": "^10.1.0",
-    "slugify": "^1.1.0"
+    "react-element-to-jsx-string": "^10.1.0"
   }
 }

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -9,7 +9,8 @@ const pick = (dict, keys) =>
 module.exports.dlls = {
   // modules required for regular bundle
   vendor: [
-    'dom-select'
+    'dom-select',
+    'querystring'
   ],
 
   // modules required for styleguide
@@ -18,12 +19,11 @@ module.exports.dlls = {
     'react',
     'react-dom/server',
     'prop-types',
-    // 'react-modal', // failing on windows build in DLL
     'minimatch',
     'pretty',
     'prismjs',
     'react-element-to-jsx-string',
-    'slugify'
+    'rand-token'
   ],
 
   // modules required for tests

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -1,4 +1,5 @@
-import slugify from 'slugify';
+import RandToken from 'rand-token';
+import { parse } from 'querystring';
 
 import Heading from '@sg-tags/SgHeading/SgHeading';
 import Rhythm from '@sg-tags/SgRhythm/SgRhythm';
@@ -29,45 +30,56 @@ SgStyleguide_Readme.propTypes = {
 };
 
 
-export const SgStyleguide_Examples = (props) => (
-  <div id="examples" className="SgStyleguide__section">
-    <Rhythm className="SgStyleguide__section-header">
-      <Heading level="h2">Examples</Heading>
+export const SgStyleguide_Examples = (props) => {
+  const { theme } = parse(location.search.substr(1));
+  const examples = props.examples
+    .filter((ex) => {
+      if (theme) {
+        return theme === ex.theme || ex.theme === undefined;
+      }
+      return true;
+    })
+    .map((ex) => {
+      const slug = ex.name.split(' ').map((s) => s.replace(/\W/g, '')).join('-').toLowerCase();
+      return Object.assign({}, ex, {
+        slug: `${slug}-${RandToken.generate(8)}`
+      });
+    });
 
-      <Rhythm size="small">
-        {
-          props.examples.map((e) => (
-            <div
-              key={`${slugify(e.name)}-${e.theme}`}
-              className={`SgStyleguide__example-link ${e.theme || 'generic'}-theme-section`}
-            >
-              <a
-                href={`#${slugify(e.name)}-${e.theme}`}
-                value={slugify(e.name)}
-              >
-                {e.name}
-              </a>
-            </div>
-          ))
-        }
+
+  return (
+    <div id="examples" className="SgStyleguide__section">
+      <Rhythm className="SgStyleguide__section-header">
+        <Heading level="h2">Examples</Heading>
+
+        <Rhythm size="small">
+          {
+            examples.map((e) => (
+              <div key={e.slug} className="SgStyleguide__example-link">
+                <a href={`#${e.slug}`} value={e.name}>
+                  {e.name}
+                </a>
+              </div>
+            ))
+          }
+        </Rhythm>
       </Rhythm>
-    </Rhythm>
 
-    {
-      props.examples.map((e) => (
-        <Example
-          key={`${slugify(e.name)}-${e.theme}`}
-          slug={`${slugify(e.name)}-${e.theme}`}
-          tagName={e.name}
-          theme={e.theme}
-          exampleName={e.name}
-          component={e.component}
-          options={e.options}
-        />
-      ))
-    }
-  </div>
-);
+      {
+        examples.map((e) => (
+          <Example
+            key={e.slug}
+            slug={e.slug}
+            exampleName={e.name}
+            component={e.component}
+            theme={e.theme}
+            options={e.options}
+          />
+        ))
+      }
+    </div>
+  );
+};
 
 SgStyleguide_Examples.propTypes = {
   examples: PropTypes.arrayOf(PropTypes.shape({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7549,6 +7549,10 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+rand-token@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-0.3.0.tgz#32c0e672200867766a13601a21cef98ac67478c7"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -8269,10 +8273,6 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slugify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.1.0.tgz#7e5b0938d52b5efab1878247ef0f6a4f05db7ee0"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
- updates `fc-config.js` dll section defaults 
- updates styleguide anchor logic to allow duplicate names
- Adds `rand-token@^0.3.0` to dependencies
- removes `slugify@^1.1.0` from dependencies