### PR TITLE
2.0.1 Dev Release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,28 @@
 # History
 
-This file keeps a list of changes between versions.
+This file keeps a list of changes between revisions.
 
 
-## 2.0.0 Changes
+## 2.0.1 Release
+
+Fixes minor bugs and some instant feedback while upgrading a project.
+
+### Changes
+
+- Adds `enhanced-resolve@^3.4.1` dependency to yarn and packages (#256)
+- Adds `postcss-mixins@^6.0.1` to postcss-plugin list by default since @apply went away in cssnext
+- Adds `rand-token@^0.3.0` to dependencies
+- Removes `slugify@^1.1.0` from dependencies
+- Updates readmes to use correct scaffolding-cli commands and add notes on the fc-config file (#252).
+- Fixes a typo in the gulp scaffolding config for compositions
+- Update clean-pre gulp task to clean correct directory `static` instead of old `vendor` folder
+- Updates `build` to exclude common assets in `static` from webpack loaders (this means you cannot practically include static assets into a bundle)
+- Updates fc-config.js dll section defaults
+- Updates styleguide anchor logic to allow duplicate names
+- Remove `postcss` plugins from `fc-config.js` because it could be sucked up into webpack and cause critical dependencies (will revisit postcss config in a 2.x type release).
+
+
+## 2.0.0 Release
 
 Dependencies have been updated to their latest versions, the most major change was from Webpack 1 to Webpack 3.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ The `BASE_URL` defines the root path where the bundled files will be located.  I
 BASE_URL=/this-path/ npm run build
 ```
 
+
+## Configuration
+
+### fc-config
+
+`source/fc-config.js` is used to configure the fuzzy chainsaw build tools.  This is where you can define webpack bundles, dll bundles, and theme options.
+
+By default FC is setup with a `generic` theme, but this can be removed or updated depending on if you need multibrand/multi-theme support.
+
+
 ## Goals
 
 We have tried to be thoughtful in our architectural decisions, and drive based on a few goals:
@@ -134,15 +144,31 @@ This might be subtitled, Unix Philosophy.  The system should be composed of many
 
 We were inspired by the patterns in Brad Frost's [Atomic Design](http://atomicdesign.bradfrost.com/table-of-contents/) and Lonely Planet's [Rizzo](https://github.com/lonelyplanet/rizzo) component API.  Our goal is to think about user interfaces as compositions of many small components. We've tried to build tools that help us think in this fashion.
 
-Components are written using React JSX, which provides a great model for composing component and managing dependencies.  Components are split into two categories, __Tags__ or __Components__. Tags are generally more reuseable, whereas Components are generally connected more directly to a CMS data model.
+Components are written using React JSX, which provides a great model for composing component and managing dependencies.  Elements are split into two categories, __Tags__, __Components__, __Compositions__. Tags will be mostly generic small elements, where components and compositions are collections of smaller elements.
 
 #### Tags
 
 Found in `/source/tags`
 
+Tags are small, reuseable elements that can be used in many contexts.
+
 #### Components
 
 Found in `/source/components`
+
+Components are generally more singular purpose elements that are tied to a business requirement, or complex reusuable elmenets that require internal state.
+
+#### Compositions
+
+Found in `/source/compositions`
+
+Compositions are specific arrangments of Tags and Components with minimal styling requirements.
+
+#### Modifiers
+
+Found in `/source/modifiers`
+
+Modifiers are css styles and/or javascript containers that don't require specific html be defined.
 
 
 ### Reuseability between projects
@@ -164,18 +190,19 @@ The web development world is evolving rapidly. A tool that can automate the myri
 
 #### Building and watching
 
-There are some very helpful command line scripts to help with development and continuous-integration. You can build a static set of files using `npm run build` or `npm run production` and create a local server to preview using `npm run start`. Use `npm run watch` if you are developing, this creates a server at http://localhost:8080 that updates as file changes.
+There are some very helpful command line scripts to help with development and continuous-integration. You can build a static set of files using `npm run build` or `npm run production` and create a local server to preview using `npm run start`. Use `npm run dev` if you are developing, this creates a server at http://localhost:8080 that updates as file changes.
 
 #### Scaffolding components
 
 Since you will likely be creating a number of tags and components, there are also some commands to help with that common task.
 
 ```
-npm run new-tag [Name]
-npm run new-component [Name]
+npm run new:tag [Name]
+npm run new:component [Name]
+npm run new:composition [Name]
 ```
 
-> Remember that component names use [PascalCase](https://en.wikipedia.org/wiki/PascalCase)
+> Remember that elements names use [PascalCase](https://en.wikipedia.org/wiki/PascalCase)
 
 
 ## FAQ
@@ -207,4 +234,4 @@ Fuzzy Chainsaw was developed to work best with Node's [most recent LTS release](
 
 ## License
 
-MIT Copyright (c) 2016 Connective DX
+MIT Copyright (c) 2017 Connective DX

--- a/build/clean-pre.js
+++ b/build/clean-pre.js
@@ -15,7 +15,7 @@ module.exports = () => (
     dest('assets/images/**'),
     dest('assets/offline/**'),
     dest('assets/svgs/*'),
-    dest('assets/vendor/*')
+    dest('assets/static/*')
   ], {
     force: true
   })

--- a/build/webpack/lib/postcss-plugins.js
+++ b/build/webpack/lib/postcss-plugins.js
@@ -10,6 +10,7 @@ const cssnext = require('postcss-cssnext');
 const extend = require('postcss-extend');
 const discardEmpty = require('postcss-discard-empty');
 const removeRoot = require('postcss-remove-root');
+const mixins = require('postcss-mixins');
 
 // build
 const mqpacker = require('css-mqpacker');
@@ -59,6 +60,7 @@ const standard = [
     }
   }),
   extend(),
+  mixins(),
   ...postcssPlugins.build,
   discardEmpty(),
   removeRoot()

--- a/build/webpack/lib/postcss-plugins.js
+++ b/build/webpack/lib/postcss-plugins.js
@@ -33,8 +33,6 @@ const CachedInputFileSystem = require('enhanced-resolve/lib/CachedInputFileSyste
 const { source } = require('../../lib/path-helpers');
 const { resolve } = require('../workflow/shared');
 
-const { postcssPlugins } = require(source('fc-config')); // eslint-disable-line
-
 
 const fileSystem = new CachedInputFileSystem(new NodeJsInputFileSystem(), 60000);
 const resolver = ResolverFactory.createResolver({
@@ -61,7 +59,6 @@ const standard = [
   }),
   extend(),
   mixins(),
-  ...postcssPlugins.build,
   discardEmpty(),
   removeRoot()
 ];
@@ -90,6 +87,5 @@ module.exports.build = [
 
 
 module.exports.production = [
-  ...postcssPlugins.production,
   cssnano()
 ];

--- a/build/webpack/workflow/browser.js
+++ b/build/webpack/workflow/browser.js
@@ -22,6 +22,7 @@ module.exports = (
         rules: [
           {
             test: /\.(woff|woff2|eot|ttf|otf)$/i,
+            exclude: /static/,
             loader: 'file-loader',
             options: {
               context: './source/',
@@ -30,10 +31,12 @@ module.exports = (
           },
           {
             test: /\.json$/,
+            exclude: /static/,
             use: 'json-loader'
           },
           {
             test: /\.md$/,
+            exclude: /static/,
             use: [
               'html-loader',
               'markdown-loader'
@@ -41,6 +44,7 @@ module.exports = (
           },
           {
             test: /\.(jpe?g|png|gif|svg)$/i,
+            exclude: /static/,
             use: [
               {
                 loader: 'file-loader',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -94,7 +94,7 @@ gulp.task('scaffold:component', scaffoldFactory({
 // gulp scaffold:composition --name [name]
 gulp.task('scaffold:composition', scaffoldFactory({
   src: 'stateless-component',
-  dest: 'composition'
+  dest: 'compositions'
 }));
 
 // gulp scaffold:component:stateful --name [name]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuzzy-chainsaw",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Boilerplate for component-based UI development",
   "repository": "connectivedx/fuzzy-chainsaw",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cssnano": "^3.7.7",
     "del": "^3.0.0",
     "dopl": "0.2.0",
+    "enhanced-resolve": "^3.4.1",
     "enzyme": "^2.9.1",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -131,9 +131,9 @@
     "pretty": "^2.0.0",
     "pretty-data": "^0.40.0",
     "prop-types": "^15.5.10",
+    "rand-token": "^0.3.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-element-to-jsx-string": "^10.1.0",
-    "slugify": "^1.1.0"
+    "react-element-to-jsx-string": "^10.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "postcss-extend": "^1.0.5",
     "postcss-import": "^10.0.0",
     "postcss-loader": "^2.0.6",
+    "postcss-mixins": "^6.0.1",
     "postcss-nested": "^2.0.3",
     "postcss-pipeline-webpack-plugin": "^3.0.0",
     "postcss-remove-root": "^0.0.2",

--- a/source/bundle.jsx
+++ b/source/bundle.jsx
@@ -11,7 +11,7 @@ import '@lib/offline-runtime';
 import select from 'dom-select';
 
 // program
-const rootEl = select('.root'); // eslint-disable-line
+const html = select('html');
 
 // remove no-js class
-rootEl.classList.remove('no-js');
+html.classList.remove('no-js');

--- a/source/elements/modifiers/README.md
+++ b/source/elements/modifiers/README.md
@@ -1,3 +1,3 @@
 # Modifiers
 
-Modifiers are css styles and/or javascript containers that doesn't require specific html be defined.
+Modifiers are css styles and/or javascript containers that don't require specific html be defined.

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -84,10 +84,3 @@ module.exports.themes = [{
   id: 'generic',
   name: 'Generic'
 }];
-
-// define additional postcss plugins to
-// add to the standard plugins
-module.exports.postcssPlugins = {
-  build: [],
-  production: []
-};

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -9,7 +9,8 @@ const pick = (dict, keys) =>
 module.exports.dlls = {
   // modules required for regular bundle
   vendor: [
-    'dom-select'
+    'dom-select',
+    'querystring'
   ],
 
   // modules required for styleguide
@@ -18,12 +19,11 @@ module.exports.dlls = {
     'react',
     'react-dom/server',
     'prop-types',
-    // 'react-modal', // failing on windows build in DLL
     'minimatch',
     'pretty',
     'prismjs',
     'react-element-to-jsx-string',
-    'slugify'
+    'rand-token'
   ],
 
   // modules required for tests

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -224,7 +224,7 @@ export const SgExample = (props) => {
 
 SgExample.defaultProps = {
   options: { },
-  theme: themes[0].id
+  theme: themes.length > 0 ? themes[0].id : undefined
 };
 
 SgExample.propTypes = {

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -1,4 +1,5 @@
-import slugify from 'slugify';
+import RandToken from 'rand-token';
+import { parse } from 'querystring';
 
 import Heading from '@sg-tags/SgHeading/SgHeading';
 import Rhythm from '@sg-tags/SgRhythm/SgRhythm';
@@ -29,45 +30,56 @@ SgStyleguide_Readme.propTypes = {
 };
 
 
-export const SgStyleguide_Examples = (props) => (
-  <div id="examples" className="SgStyleguide__section">
-    <Rhythm className="SgStyleguide__section-header">
-      <Heading level="h2">Examples</Heading>
+export const SgStyleguide_Examples = (props) => {
+  const { theme } = parse(location.search.substr(1));
+  const examples = props.examples
+    .filter((ex) => {
+      if (theme) {
+        return theme === ex.theme || ex.theme === undefined;
+      }
+      return true;
+    })
+    .map((ex) => {
+      const slug = ex.name.split(' ').map((s) => s.replace(/\W/g, '')).join('-').toLowerCase();
+      return Object.assign({}, ex, {
+        slug: `${slug}-${RandToken.generate(8)}`
+      });
+    });
 
-      <Rhythm size="small">
-        {
-          props.examples.map((e) => (
-            <div
-              key={`${slugify(e.name)}-${e.theme}`}
-              className={`SgStyleguide__example-link ${e.theme || 'generic'}-theme-section`}
-            >
-              <a
-                href={`#${slugify(e.name)}-${e.theme}`}
-                value={slugify(e.name)}
-              >
-                {e.name}
-              </a>
-            </div>
-          ))
-        }
+
+  return (
+    <div id="examples" className="SgStyleguide__section">
+      <Rhythm className="SgStyleguide__section-header">
+        <Heading level="h2">Examples</Heading>
+
+        <Rhythm size="small">
+          {
+            examples.map((e) => (
+              <div key={e.slug} className="SgStyleguide__example-link">
+                <a href={`#${e.slug}`} value={e.name}>
+                  {e.name}
+                </a>
+              </div>
+            ))
+          }
+        </Rhythm>
       </Rhythm>
-    </Rhythm>
 
-    {
-      props.examples.map((e) => (
-        <Example
-          key={`${slugify(e.name)}-${e.theme}`}
-          slug={`${slugify(e.name)}-${e.theme}`}
-          tagName={e.name}
-          theme={e.theme}
-          exampleName={e.name}
-          component={e.component}
-          options={e.options}
-        />
-      ))
-    }
-  </div>
-);
+      {
+        examples.map((e) => (
+          <Example
+            key={e.slug}
+            slug={e.slug}
+            exampleName={e.name}
+            component={e.component}
+            theme={e.theme}
+            options={e.options}
+          />
+        ))
+      }
+    </div>
+  );
+};
 
 SgStyleguide_Examples.propTypes = {
   examples: PropTypes.arrayOf(PropTypes.shape({

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -31,12 +31,16 @@ SgStyleguide_Readme.propTypes = {
 
 
 export const SgStyleguide_Examples = (props) => {
-  const { theme } = parse(location.search.substr(1));
+  const theme = global.location
+    ? parse(global.location.search.substr(1)).theme
+    : themes[0].id;
+
   const examples = props.examples
     .filter((ex) => {
       if (theme) {
         return theme === ex.theme || ex.theme === undefined;
       }
+
       return true;
     })
     .map((ex) => {

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -31,9 +31,9 @@ SgStyleguide_Readme.propTypes = {
 
 
 export const SgStyleguide_Examples = (props) => {
-  const theme = global.location
+  const theme = global.location // eslint-disable-line
     ? parse(global.location.search.substr(1)).theme
-    : themes[0].id;
+    : themes.length > 0 ? themes[0].id : undefined;
 
   const examples = props.examples
     .filter((ex) => {

--- a/source/styleguide/tags/SgFileIndex/SgFileIndex.jsx
+++ b/source/styleguide/tags/SgFileIndex/SgFileIndex.jsx
@@ -6,9 +6,11 @@ import { themes } from '@source/fc-config';
 const SgFileIndex__ItemThemed = (props) => {
   const { url, content } = props.item;
 
+  const firstTheme = themes.length ? `?theme=${themes[0].id}` : '';
+
   return (
     <li>
-      <a className="SgFileIndex__name" href={`${url}?theme=${themes[0].id}`}>{content}</a>
+      <a className="SgFileIndex__name" href={`${url}${firstTheme}`}>{content}</a>
       { themes.length > 1 &&
         <span className="SgFileIndex__links">
           ({ themes

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,6 +1243,10 @@ camel-case@3.0.x:
     no-case "^2.2.0"
     upper-case "^1.1.1"
 
+camelcase-css@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-1.0.1.tgz#157c4238265f5cf94a1dffde86446552cbf3f705"
+
 camelcase-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
@@ -6953,6 +6957,13 @@ postcss-initial@^2.0.0:
     lodash.template "^4.2.4"
     postcss "^6.0.1"
 
+postcss-js@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-1.0.0.tgz#ccee5aa3b1970dd457008e79438165f66919ba30"
+  dependencies:
+    camelcase-css "^1.0.1"
+    postcss "^6.0.1"
+
 postcss-less@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-0.14.0.tgz#c631b089c6cce422b9a10f3a958d2bedd3819324"
@@ -7061,6 +7072,16 @@ postcss-minify-selectors@^2.0.4:
     has "^1.0.1"
     postcss "^5.0.14"
     postcss-selector-parser "^2.0.0"
+
+postcss-mixins@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-mixins/-/postcss-mixins-6.0.1.tgz#f5c9726259a6103733b43daa6a8b67dd0ed7aa47"
+  dependencies:
+    globby "^6.1.0"
+    postcss "^6.0.3"
+    postcss-js "^1.0.0"
+    postcss-simple-vars "^4.0.0"
+    sugarss "^1.0.0"
 
 postcss-modules-extract-imports@^1.0.0:
   version "1.2.0"
@@ -7234,6 +7255,12 @@ postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.1.1, postcss-selector
     flatten "^1.0.2"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+
+postcss-simple-vars@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-4.0.0.tgz#d49e082897d9a4824f2268fa91d969d943e2ea76"
+  dependencies:
+    postcss "^6.0.1"
 
 postcss-svgo@^2.1.1:
   version "2.1.6"
@@ -8780,6 +8807,12 @@ sugarss@^0.2.0:
   resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-0.2.0.tgz#ac34237563327c6ff897b64742bf6aec190ad39e"
   dependencies:
     postcss "^5.2.4"
+
+sugarss@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-1.0.0.tgz#65e51b3958432fb70d5451a68bb33e32d0cf1ef7"
+  dependencies:
+    postcss "^6.0.0"
 
 sum-up@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,6 +2641,15 @@ enhanced-resolve@^3.3.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
+enhanced-resolve@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    object-assign "^4.0.1"
+    tapable "^0.2.7"
+
 enhanced-resolve@~0.9.0:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
@@ -8893,6 +8902,10 @@ tapable@^0.1.8, tapable@~0.1.8:
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.6.tgz#206be8e188860b514425375e6f1ae89bfb01fd8d"
+
+tapable@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.7.tgz#e46c0daacbb2b8a98b9b0cea0f4052105817ed5c"
 
 tape@^4.7.0:
   version "4.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7585,6 +7585,10 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+rand-token@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-0.3.0.tgz#32c0e672200867766a13601a21cef98ac67478c7"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -8305,10 +8309,6 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slugify@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.1.0.tgz#7e5b0938d52b5efab1878247ef0f6a4f05db7ee0"
 
 sntp@1.x.x:
   version "1.0.9"


### PR DESCRIPTION
# 2.0.1 Dev Release

Fixes minor bugs and some instant feedback while upgrading a project.

## Changes

- Adds `enhanced-resolve@^3.4.1` dependency to yarn and packages (#256)
- Adds `postcss-mixins@^6.0.1` to postcss-plugin list by default since @apply went away in cssnext
- Adds `rand-token@^0.3.0` to dependencies
- Removes `slugify@^1.1.0` from dependencies
- Updates readmes to use correct scaffolding-cli commands and add notes on the fc-config file (#252).
- Fixes a typo in the gulp scaffolding config for compositions
- Update clean-pre gulp task to clean correct directory `static` instead of old `vendor` folder
- Updates `build` to exclude common assets in `static` from webpack loaders (this means you cannot practically include static assets into a bundle)
- Updates fc-config.js dll section defaults 
- Updates styleguide anchor logic to allow duplicate names
- Remove `postcss` plugins from `fc-config.js` because it could be sucked up into webpack and cause critical dependencies (will revisit postcss config in a 2.x type release).


## Updating from 2.0.0

1. Download a copy of 2.0.1 ([download](https://github.com/connectivedx/fuzzy-chainsaw/archive/2.0.1.zip))
2. Replace `build` directory with FC@2.0.1 `build` directory
3. Replace `source/styleguide` directory with FC@2.0.1 `source/styleguide` directory
4. Remove `postcssPlugins` export from `source/fc-config.js`
5. Update `dll` configuration in `fc-config.js`
  a. Adds `querystring` to vendor dll array
  b. Adds `rand-token` to the styleguide dll array
  c. Remove `slugify` from styleguide dll array
6. Update package dependencies:
  a. `yarn remove slugify@^1.1.0`
  b. `yarn add enhanced-resolve@^3.4.1 postcss-mixins@^6.0.1 rand-token@^0.3.0 --dev`
7. Optionally, Update `README.md`
8. Optionally, Update `package.json` version