### PR TITLE
2.0.2 Release

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,13 @@
 
 This file keeps a list of changes between revisions.
 
+## 2.0.2 Release
+
+Fixes a major bug related to outputing bundles files outside of the project directory root.
+
+ - Injects `module.paths = require.main.paths` at the start static.js before build render
+ - Moves postcss-mixins plugin to the start of the postcss pipeline to solve an issue with unexpanded selectors.
+
 
 ## 2.0.1 Release
 

--- a/build/static-render-factory.js
+++ b/build/static-render-factory.js
@@ -18,7 +18,26 @@ const {
 } = require('./lib/render-helpers');
 
 
+/*
+  When the output directory is outside of the directory containing
+  node_modules, we need to force the module resolution algorithm to use
+  this file's node_module search paths instead of the desination.
+*/
+const injectModulePaths = (staticPath) => {
+  const staticBundle = fs.readFileSync(staticPath);
+
+  const fixedStaticBundle =
+    staticBundle.indexOf('module.paths = require.main.paths') === -1
+      ? `module.paths = require.main.paths;${staticBundle}`
+      : staticBundle;
+
+  fs.writeFileSync(staticPath, fixedStaticBundle);
+};
+
+
 module.exports = ({ production }) => () => {
+  injectModulePaths(dest('tmp/static.js'));
+
   const pageTemplate = fs.readFileSync(dest('_skeleton.html'));
   const {
     pagesContext,

--- a/build/webpack/lib/postcss-plugins.js
+++ b/build/webpack/lib/postcss-plugins.js
@@ -51,6 +51,7 @@ module.exports.linting = [
 
 
 const standard = [
+  mixins(),
   nested(),
   cssnext({
     features: {
@@ -58,7 +59,6 @@ const standard = [
     }
   }),
   extend(),
-  mixins(),
   discardEmpty(),
   removeRoot()
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuzzy-chainsaw",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Boilerplate for component-based UI development",
   "repository": "connectivedx/fuzzy-chainsaw",
   "bugs": {


### PR DESCRIPTION
- Adds logic to inject `module.paths = require.main.paths` at the start static.js before build render to allow rendering outside of the root directory
- Moves `postcss-mixins` plugin to the start of the postcss pipeline to solve an issue with unexpanded selectors.

## Steps to upgrade project

- Replace project `build/static-render-factory.js` with new copy from FC
- Replace project `build/webpack/lib/postcss-plugins.js` with new copy from FC
- Replace project `history.md` with new copy from FC
- Update `package.json` version to 2.0.2

## Steps to test PR

1. Pull down PR branch
2. Update `directories` in `package.json` to reference an external directory – like `../test-dist`
3. Run `npm run full:build`
4. Verify output via `npm run start`