### PR TITLE
2.0.3 Release

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,7 @@
   "presets": ["es2015", "react"],
   "plugins": [
 	"transform-object-rest-spread",
-	"transform-class-properties"
+	"transform-class-properties",
+	"add-react-displayname"
   ]
 }

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,9 +2,22 @@
 
 This file keeps a list of changes between revisions.
 
+
+## 2.0.3 Release
+
+Fixes styleguide rendering bugs related to the way code examples were being processsed that would cause IE11 to fail and generate unuseable markup examples.
+
+### Changes
+
+- Adds `babel-plugin-add-react-displayname@^0.0.4` to `package.json` devDependencies and `.babelrc`
+- Updates `SgExample` styleguide component to output code examples correctly.
+
+
 ## 2.0.2 Release
 
 Fixes a major bug related to outputing bundles files outside of the project directory root.
+
+### Changes
 
  - Injects `module.paths = require.main.paths` at the start static.js before build render
  - Moves postcss-mixins plugin to the start of the postcss pipeline to solve an issue with unexpanded selectors.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^7.1.1",
+    "babel-plugin-add-react-displayname": "^0.0.4",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuzzy-chainsaw",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Boilerplate for component-based UI development",
   "repository": "connectivedx/fuzzy-chainsaw",
   "bugs": {

--- a/source/styleguide/components/SgExample/SgExample.Container.jsx
+++ b/source/styleguide/components/SgExample/SgExample.Container.jsx
@@ -7,8 +7,8 @@ export default (el) => {
     const active = items.map((item) => item.contains(ev.target));
     if (active.indexOf(true) !== -1) {
       items.forEach((item, j) => {
-        items[j].classList.toggle('is-active', active[j]);
-        sections[j].classList.toggle('is-active', active[j]);
+        items[j].classList[active[j] ? 'add' : 'remove']('is-active');
+        sections[j].classList[active[j] ? 'add' : 'remove']('is-active');
       });
     }
   });

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -17,7 +17,12 @@ const filterProps = (component) => {
 
   const processChild = (child) => (
     Object.keys(child)
-      .filter((key) => !(child[key] === null || Object.keys(child[key]).length === 0))
+      .filter((key) => {
+        if (!child[key]) return false;
+        if (Array.isArray(child[key])) return child[key].length > 0;
+        if (typeof child[key] === 'object') return Object.keys(child[key]).length > 0;
+        return false;
+      })
       .reduce((sum, key) => {
         if (key === 'props' && child.props.children !== undefined) {
           let children = child.props.children;

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -180,13 +180,10 @@ export const SgExample = (props) => {
   } = props;
 
   const reactExample = reactElementToString(component, {
-    displayName: (element) => {
-      if (typeof element.type === 'string') return element.type;
-      if (element.type.name) return element.type.name;
-      if (element.props && element.props.tagName) return element.props.tagName;
-      return 'unknown-element';
-    }
+    displayName: getTagName,
+    showDefaultProps: false
   });
+
   const htmlExample = Dom.renderToStaticMarkup(component);
   const jsonExample = JSON.stringify(filterProps(component), null, 2);
 

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -9,45 +9,63 @@ import SgHeading from '@sg-tags/SgHeading/SgHeading';
 import { themes } from '@source/fc-config';
 
 
+const getTagName = (element) => {
+  if (typeof element === 'string') return element;
+  if (typeof element.type === 'string') return element.type;
+  if (element.type.displayName) return element.type.displayName;
+  if (element.type.name) return element.type.name;
+  if (element.props && element.props.tagName) return element.props.tagName;
+  return 'unknown-element';
+};
+
+
 const filterProps = (component) => {
-  const copy = {
-    type: component.type.name,
-    props: Object.assign({}, component.props)
+  const pickInfo = (obj) =>
+    Object.keys(obj).reduce((res, key) => {
+      if (key === 'type') res[key] = getTagName({ type: obj.type });
+      if (key === 'props') {
+        res[key] = Object.assign({}, obj.props);
+
+        // skip default props
+        if (obj.type.defaultProps) {
+          Object.keys(obj.type.defaultProps).forEach((propKey) => {
+            delete res.props[propKey];
+          });
+        }
+      }
+
+      return res;
+    }, { });
+
+  const processChild = (childComponent) => {
+    const getChildren = (children) => {
+      if (Array.isArray(children)) {
+        return children.map(processChild);
+      } else if (typeof children === 'object') {
+        return [
+          processChild(children)
+        ];
+      }
+
+      return children;
+    };
+
+    if (typeof childComponent === 'string') {
+      return childComponent;
+    }
+
+    const info = pickInfo(childComponent);
+    if (childComponent.props.children) {
+      info.props.children = getChildren(childComponent.props.children);
+    }
+
+    return info;
   };
 
-  const processChild = (child) => (
-    Object.keys(child)
-      .filter((key) => {
-        if (!child[key]) return false;
-        if (Array.isArray(child[key])) return child[key].length > 0;
-        if (typeof child[key] === 'object') return Object.keys(child[key]).length > 0;
-        return false;
-      })
-      .reduce((sum, key) => {
-        if (key === 'props' && child.props.children !== undefined) {
-          let children = child.props.children;
+  const copy = pickInfo(component);
 
-          if (Array.isArray(children)) {
-            children = child.props.children.map(processChild);
-          } else if (typeof children === 'object') {
-            children = processChild(children);
-          }
-
-          sum.props = Object.assign({ }, child.props, { children });
-        } else if (key === 'type') {
-          if (child.type && child.type.name) sum.type = child.type.name;
-          else sum.type = child.type;
-        } else {
-          sum[key] = child[key];
-        }
-
-        return sum;
-      }, { })
-  );
-
-
-  if (Array.isArray(copy.props.children)) {
-    copy.props.children = copy.props.children.map(processChild);
+  if (Array.isArray(component.props.children)) {
+    copy.props.children = component.props.children.map(processChild);
   }
 
   return copy;

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -179,7 +179,14 @@ export const SgExample = (props) => {
     component
   } = props;
 
-  const reactExample = reactElementToString(component);
+  const reactExample = reactElementToString(component, {
+    displayName: (element) => {
+      if (typeof element.type === 'string') return element.type;
+      if (element.type.name) return element.type.name;
+      if (element.props && element.props.tagName) return element.props.tagName;
+      return 'unknown-element';
+    }
+  });
   const htmlExample = Dom.renderToStaticMarkup(component);
   const jsonExample = JSON.stringify(filterProps(component), null, 2);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,6 +524,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-react-displayname@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.4.tgz#bc2a74bcbee6e505025b3352fea85ee7bc4c6f7c"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
## Changes

- Adds `babel-plugin-add-react-displayname@^0.0.4` to `package.json` devDependencies and `.babelrc`
- Updates `SgExample` styleguide component to output code examples correctly.


## Steps to test PR

The RichText / Media pages in IE11 are what was failing before (#273), please do these things using IE11 (via browserstack is fine):

1. Run `npm run dev`, verify output
2. Run `npm run full:build`, Verify output by running `npm run start`


## Steps to upgrade project

- Replace project `source/styleguide/components/SgExample/SgExample.jsx` with new FC copy
- Replace project `source/styleguide/components/SgExample/SgExample.Container.jsx` with new FC copy
- Replace project `.babelrc` with new copy from FC
- Replace project `history.md` with new copy from FC
- Update `package.json` version to `2.0.3`