### PR TITLE
BASE_URL tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,18 @@ DLLs are libraries of vendor files that are referenced by other tasks.  This spe
 
 #### BASE_URL
 
-The `BASE_URL` defines the root path where the bundled files will be located.  If you are uploading to a non-root path on a server (`http://myserver.com/this-path`) this will need to be defined.
+The `BASE_URL` defines the root path where the bundled files will be located.  If you are uploading to a non-root path on a server (`http://myserver.com/this-path`) this will need to be defined. This can be done on a one-off basis via build commands, or permanently via `package.json`.
+
+##### Build Command
 
 ```
 BASE_URL=/this-path/ npm run build
+```
+
+##### Package.json
+
+```
+"baseUrl": "/this-path/",
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ DLLs are libraries of vendor files that are referenced by other tasks.  This spe
 
 #### BASE_URL
 
-The `BASE_URL` defines the root path where the bundled files will be located.  If you are uploading to a non-root path on a server (`http://myserver.com/this-path`) this will need to be defined. This can be done on a one-off basis via build commands, or permanently via `package.json`.
+The `BASE_URL` defines the root path where the bundled files will be located.  If you are uploading to a non-root path on a server (`http://myserver.com/this-path/`) this will need to be defined. This can be done on a one-off basis via build commands, or permanently via `package.json`.
+
+If you are developing locally, or if your project will be served at the root of a domain or IP (`http://myserver.com/` or `http://133.713.37/`), you don't have to worry about configuring the `BASE_URL` at all.
 
 ##### Define via build commands
 
@@ -125,7 +127,7 @@ BASE_URL=/this-path/ npm run build
 "baseUrl": "/this-path/",
 ```
 
-_Note: `BASE_URL` should always have leading and trailing slashes._
+_Note: `BASE_URL` should always have a leading and trailing slash._
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ BASE_URL=/this-path/ npm run build
 "baseUrl": "/this-path/",
 ```
 
+_Note: `BASE_URL` should always have leading and trailing slashes._
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ DLLs are libraries of vendor files that are referenced by other tasks.  This spe
 
 The `BASE_URL` defines the root path where the bundled files will be located.  If you are uploading to a non-root path on a server (`http://myserver.com/this-path`) this will need to be defined. This can be done on a one-off basis via build commands, or permanently via `package.json`.
 
-##### Build Command
+##### Define via build commands
 
 ```
 BASE_URL=/this-path/ npm run build
 ```
 
-##### Package.json
+##### Define via package.json
 
 ```
 "baseUrl": "/this-path/",

--- a/build/lib/path-helpers.js
+++ b/build/lib/path-helpers.js
@@ -11,10 +11,11 @@ const { directories, baseUrl: packageBaseUrl } = require(path.resolve(pkgpath.se
 const source = (...paths) => path.resolve(pkgpath.self(), directories.source, ...paths);
 const dest = (...paths) => path.resolve(pkgpath.self(), directories.dest, ...paths);
 
-// dev always serves from root (http://localhost:8080),
+// dev always serves from root (localhost:8080),
 // so only use baseUrl if task is not dev-related
 const devTasks = ['dev', 'build:dev', 'test:dev'];
-const baseUrl = devTasks.indexOf(process.env.npm_lifecycle_event) ? '/' : process.env.BASE_URL || packageBaseUrl || '/';
+const baseUrl = devTasks.includes(process.env.npm_lifecycle_event) ? '/' : process.env.BASE_URL || packageBaseUrl || '/';
+
 
 // This takes a simple object of entry:filepath pairs
 // and runs each filepath through the source() helper

--- a/build/lib/path-helpers.js
+++ b/build/lib/path-helpers.js
@@ -8,12 +8,13 @@ const path = require('path');
 const pkgpath = require('packpath');
 
 const { directories, baseUrl: packageBaseUrl } = require(path.resolve(pkgpath.self(), 'package.json')); // eslint-disable-line
-
-
-const baseUrl = process.env.BASE_URL || packageBaseUrl || '/';
 const source = (...paths) => path.resolve(pkgpath.self(), directories.source, ...paths);
 const dest = (...paths) => path.resolve(pkgpath.self(), directories.dest, ...paths);
 
+// dev always serves from root,
+// so only use baseUrl if task is not dev-related
+const devTasks = ['dev', 'build:dev', 'test:dev'];
+const baseUrl = devTasks.indexOf(process.env.npm_lifecycle_event) ? '/' : process.env.BASE_URL || packageBaseUrl || '/';
 
 // This takes a simple object of entry:filepath pairs
 // and runs each filepath through the source() helper

--- a/build/lib/path-helpers.js
+++ b/build/lib/path-helpers.js
@@ -11,7 +11,7 @@ const { directories, baseUrl: packageBaseUrl } = require(path.resolve(pkgpath.se
 const source = (...paths) => path.resolve(pkgpath.self(), directories.source, ...paths);
 const dest = (...paths) => path.resolve(pkgpath.self(), directories.dest, ...paths);
 
-// dev always serves from root,
+// dev always serves from root (http://localhost:8080),
 // so only use baseUrl if task is not dev-related
 const devTasks = ['dev', 'build:dev', 'test:dev'];
 const baseUrl = devTasks.indexOf(process.env.npm_lifecycle_event) ? '/' : process.env.BASE_URL || packageBaseUrl || '/';

--- a/build/lib/path-helpers.js
+++ b/build/lib/path-helpers.js
@@ -7,17 +7,25 @@
 const path = require('path');
 const pkgpath = require('packpath');
 
+// grab what we need from package.json
 const { directories, baseUrl: packageBaseUrl } = require(path.resolve(pkgpath.self(), 'package.json')); // eslint-disable-line
+
+// check if base url is defined in package or command,
+// return root if undefined or dev task is being run
+const getBaseUrl = (devTasks) => {
+  if (devTasks && devTasks.includes(process.env.npm_lifecycle_event)) {
+    return '/';
+  }
+
+  return process.env.BASE_URL || packageBaseUrl || '/';
+};
+
+// define paths for export
 const source = (...paths) => path.resolve(pkgpath.self(), directories.source, ...paths);
 const dest = (...paths) => path.resolve(pkgpath.self(), directories.dest, ...paths);
+const baseUrl = getBaseUrl(['dev', 'build:dev', 'test:dev']);
 
-// dev always serves from root (localhost:8080),
-// so only use baseUrl if task is not dev-related
-const devTasks = ['dev', 'build:dev', 'test:dev'];
-const baseUrl = devTasks.includes(process.env.npm_lifecycle_event) ? '/' : process.env.BASE_URL || packageBaseUrl || '/';
-
-
-// This takes a simple object of entry:filepath pairs
+// this takes a simple object of entry:filepath pairs
 // and runs each filepath through the source() helper
 const sourceAll = (entry) =>
   Object.keys(entry)


### PR DESCRIPTION
## Description
LP puts FED assets into non-root folders, so using the `BASE_URL` functionality of FC is a given on basically any project that integrates with LP.

On a recent project, due to environment/build tool limitations, using `BASE_URL` via the command line was not an option. I looked into the possibility of defining it via `package.json` and found that it is actually already supported. We added a `baseUrl` property to `package.json` and it worked like a charm for builds.

There was a catch, though: it broke the `dev` command/task because the root of the dev server is always `/` (localhost:8080) and it was looking for assets at the `baseUrl` defined in `package.json` (resulting in 404s).

The fix I've come up with is to set the `baseUrl` to `/` for all dev-related commands (`dev`, `build:dev` & `test:dev`), and then fallback to the existing behavior for all other commands.

With this tweak, FC would fully support defining the `BASE_URL` via `package.json`. I've also updated the project readme to reflect the changes.

## How Has This Been Tested?
An internal project (GWP) has been using the `baseUrl` property for about a month and it works perfectly from a build standpoint. The only issue is that we (FED) have had to remove the `baseUrl` property from `package.json` to developer locally, pending this tweak. I've tested the build & dev commands and they all behave as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
