### PR TITLE
UPDATE: Preserve State in React Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,17 @@ Since you will likely be creating a number of tags and components, there are als
 npm run new:tag [Name]
 npm run new:component [Name]
 npm run new:composition [Name]
+npm run new:stateful [Name]
 ```
+
+Components come in a variety of shapes and sizes!
+
+- Tags are small, reuseable elements that can be used in many contexts.
+- Components are generally more singular purpose elements that are tied to a business requirement, or complex reusuable elmenets that require internal state.
+- Compositions are specific arrangments of Tags and Components with minimal styling requirements.
+- Stateful components are elements that require tracking of internal state properties. The scaffolding for Stateful components intends for a more application-based implementation of React.
+
+You can read more on Stateless vs. Stateful components [here](https://reactjs.org/docs/state-and-lifecycle.html)
 
 > Remember that elements names use [PascalCase](https://en.wikipedia.org/wiki/PascalCase)
 

--- a/source/dev.jsx
+++ b/source/dev.jsx
@@ -1,4 +1,4 @@
-import Dom from 'react-dom/server';
+import Dom from 'react-dom';
 import assign from 'object.assign';
 
 import { getModule } from './static';
@@ -17,7 +17,7 @@ const {
 } = getModule(location.pathname.replace(/\.html/, ''));
 
 // mock a server render
-document.querySelector('.root').innerHTML = Dom.renderToStaticMarkup(Component);
+Dom.render(Component, document.querySelector('.root'));
 document.title = pageTitle;
 
 // get module theme property or first theme in fc config

--- a/source/dev.jsx
+++ b/source/dev.jsx
@@ -8,6 +8,8 @@ import { themes } from './fc-config';
 // shim object.assign for ie11
 assign.shim();
 
+const docRoot = document.querySelector('html');
+
 const {
   pageTitle,
   theme,
@@ -23,11 +25,11 @@ document.title = pageTitle;
 // get module theme property or first theme in fc config
 if (themes.length > 0) {
   const themeId = theme || themes[0].id;
-  document.querySelector('html').classList.add(`Theme--${themeId}`);
+  docRoot.classList.add(`Theme--${themeId}`);
 }
 
 if (htmlClass) {
-  document.querySelector('html').classList.add(htmlClass);
+  docRoot.classList.add(htmlClass);
 }
 
 if (bodyClass) {

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -225,8 +225,9 @@ export const SgExample = (props) => {
         type="example"
         isActive
         className={exampleClassStack}
-        dangerouslySetInnerHTML={{ __html: htmlExample }}
-      />
+      >
+        {component}
+      </SgExample_Section>
 
       <SgExample_Section title="React" type="react">
         <pre>


### PR DESCRIPTION
Changes the way that we render components both in the Styleguide and on Pages. By using `React-Dom.render()` we preserve the 'Application' parts of React to use in our components. 

## Description
When passing a Component to the SgExample.jsx file, it uses the React Element directly instead of passing it to `renderToStaticMarkup()`.

Additionally, dev.jsx now uses `Dom.render()` for React elements.

## Motivation and Context
This preserves the 'stateful' elements of React Components so that we can build React Apps from FC.

## How Has This Been Tested?
Yes. Run `npm run new:stateful {testNameHere}`. The resulting default Component has the 'onClick' method preserved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
