### PR TITLE
Active theme links

### DIFF
--- a/source/styleguide/components/SgStyleguide/SgStyleguide.css
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.css
@@ -27,7 +27,6 @@
   }
 
   &__theme-link {
-    color: var(--color-black);
     display: inline-block;
     text-decoration: none;
     text-transform: uppercase;

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.css
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.css
@@ -20,7 +20,22 @@
   }
 
   &__themes {
-    & span { margin: auto 0.25em; }
+    & span {
+      display: inline-block;
+      margin: 0 0.5rem;
+    }
+  }
+
+  &__theme-link {
+    color: var(--color-black);
+    display: inline-block;
+    text-decoration: none;
+    text-transform: uppercase;
+
+    &--active {
+      border-bottom: 1px solid;
+      font-weight: bold;
+    }
   }
 
   &__section-header {

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -94,6 +94,24 @@ SgStyleguide_Examples.propTypes = {
   }))
 };
 
+const SgStyleguide__ThemeLinks = () => {
+  const activeTheme = global.location // eslint-disable-line
+    ? parse(global.location.search.substr(1)).theme
+    : themes.length > 0 ? themes[0].id : undefined;
+
+  return (
+    <div className="SgStyleguide__themes">
+      { themes
+        .map((theme) => <a className={theme.id === activeTheme ? 'SgStyleguide__theme-link SgStyleguide__theme-link--active' : 'SgStyleguide__theme-link'} key={theme.id} href={`?theme=${theme.id}`}>{theme.name}</a>)
+        .reduce((list, item, i) => {
+          if (i > 0) list.push(<span key={`seperator-${i}`}>/</span>);
+          list.push(item);
+          return list;
+        }, [])
+      }
+    </div>
+  );
+};
 
 export const SgStyleguide = ({
   name = 'Generic Component',
@@ -106,18 +124,7 @@ export const SgStyleguide = ({
     <div className="SgStyleguide" id="content">
       <Rhythm size="small" className="SgStyleguide__header">
         <Heading level="h1">{name}</Heading>
-        { themes.length > 1 &&
-          <div className="SgStyleguide__themes">
-            { themes
-              .map((theme) => <a key={theme.id} href={`?theme=${theme.id}`}>{theme.name}</a>)
-              .reduce((list, item, i) => {
-                if (i > 0) list.push(<span key={`seperator-${i}`}>/</span>);
-                list.push(item);
-                return list;
-              }, [])
-            }
-          </div>
-        }
+        {themes.length > 1 && <SgStyleguide__ThemeLinks />}
       </Rhythm>
 
       { readme && <SgStyleguide_Readme readme={readme} /> }


### PR DESCRIPTION
## Description
Fixes #284.

Adds new class names to the theme links in the head of each style guide tag/component page. The active theme will now display in bold and with a bottom border (see screenshot below).

## Motivation and Context
#284 

## How Has This Been Tested?
To test:
* add additional themes in `fc-config`'s `module.exports.themes` array
* view any styleguide page

## Screenshots (if appropriate):
new styles appear as below:
<img width="305" alt="themes" src="https://user-images.githubusercontent.com/1466832/31904573-852d2d62-b7e0-11e7-8a99-1eab79334707.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
