### PR TITLE
Example page(s) optional developer notes

### DIFF
--- a/build/scaffolding/stateful-component/[name].example.jsx
+++ b/build/scaffolding/stateful-component/[name].example.jsx
@@ -4,5 +4,6 @@ export default [{
   name: 'Default styling',
   component: (
     <{{name}}>Lorem ipsum</{{name}}>
-  )
+  ),
+  devNotes: ''
 }];

--- a/build/scaffolding/stateless-component/[name].example.jsx
+++ b/build/scaffolding/stateless-component/[name].example.jsx
@@ -4,5 +4,6 @@ export default [{
   name: 'Default styling',
   component: (
     <{{name}}>Lorem ipsum</{{name}}>
-  )
+  ),
+  devNotes: ''
 }];

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -194,7 +194,8 @@ export const SgExample = (props) => {
     exampleName,
     theme,
     options,
-    component
+    component,
+    devNotes
   } = props;
 
   const reactExample = reactElementToString(component, {
@@ -218,6 +219,7 @@ export const SgExample = (props) => {
         <SgExample_Tab slug={slug} name="react">React</SgExample_Tab>
         <SgExample_Tab slug={slug} name="html">HTML</SgExample_Tab>
         <SgExample_Tab slug={slug} name="json">JSON</SgExample_Tab>
+        <SgExample_Tab slug={slug} name="json">Notes</SgExample_Tab>
       </SgExample_Header>
 
       <SgExample_Section
@@ -246,6 +248,12 @@ export const SgExample = (props) => {
           <code dangerouslySetInnerHTML={{ __html: Prism.highlight(jsonExample, Prism.languages.json) }} />
         </pre>
       </SgExample_Section>
+
+      <SgExample_Section title="JSON" type="json">
+        <pre>
+          {devNotes}
+        </pre>
+      </SgExample_Section>
     </SgExample_Wrapper>
   );
 };
@@ -267,7 +275,8 @@ SgExample.propTypes = {
   component: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.element
-  ])
+  ]),
+  devNotes: PropTypes.string
 };
 
 

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -219,7 +219,7 @@ export const SgExample = (props) => {
         <SgExample_Tab slug={slug} name="react">React</SgExample_Tab>
         <SgExample_Tab slug={slug} name="html">HTML</SgExample_Tab>
         <SgExample_Tab slug={slug} name="json">JSON</SgExample_Tab>
-        <SgExample_Tab slug={slug} name="json">Notes</SgExample_Tab>
+        <SgExample_Tab slug={slug} name="notes">Notes</SgExample_Tab>
       </SgExample_Header>
 
       <SgExample_Section

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -249,7 +249,7 @@ export const SgExample = (props) => {
         </pre>
       </SgExample_Section>
 
-      <SgExample_Section title="JSON" type="json">
+      <SgExample_Section title="NOTES" type="string">
         <pre>
           {devNotes}
         </pre>

--- a/source/styleguide/components/SgExample/SgExample.jsx
+++ b/source/styleguide/components/SgExample/SgExample.jsx
@@ -219,7 +219,9 @@ export const SgExample = (props) => {
         <SgExample_Tab slug={slug} name="react">React</SgExample_Tab>
         <SgExample_Tab slug={slug} name="html">HTML</SgExample_Tab>
         <SgExample_Tab slug={slug} name="json">JSON</SgExample_Tab>
-        <SgExample_Tab slug={slug} name="notes">Notes</SgExample_Tab>
+        {devNotes &&
+          <SgExample_Tab slug={slug} name="notes">Notes</SgExample_Tab>
+        }
       </SgExample_Header>
 
       <SgExample_Section
@@ -249,11 +251,13 @@ export const SgExample = (props) => {
         </pre>
       </SgExample_Section>
 
-      <SgExample_Section title="NOTES" type="string">
-        <pre>
-          {devNotes}
-        </pre>
-      </SgExample_Section>
+      {devNotes &&
+        <SgExample_Section title="NOTES" type="string">
+          <pre>
+            {devNotes}
+          </pre>
+        </SgExample_Section>
+      }
     </SgExample_Wrapper>
   );
 };

--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -91,6 +91,7 @@ export const SgStyleguide_Examples = (props) => {
             component={e.component}
             theme={e.theme}
             options={e.options}
+            devNotes={e.devNotes}
           />
         ))
       }


### PR DESCRIPTION
## Description
This now adds a new tab to the example page(s) tabbing system for developer notes.
Notes are tied to the examples under a component/composition's example file and is a new "devNotes" property.

## Motivation and Context
When a component or composition has a number of examples variations, we are only really ever given one chance to best describe the variation differences between each example. This new Notes tab/prop allows you to expand upon each example variation in greater detail, and keeps that note within context of the actual example variation instead of at the top in the readme.

## How Has This Been Tested?
builds work
new:component works
new:composition works
new:tag works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
