### PR TITLE
Bundles Modifier CSS by default

### DIFF
--- a/source/bundle.css.jsx
+++ b/source/bundle.css.jsx
@@ -12,3 +12,4 @@ require('@tags/RichText/RichText.css');
 requireAll(require.context('@tags/', true, /\.css$/));
 requireAll(require.context('@components/', true, /\.css$/));
 requireAll(require.context('@compositions/', true, /\.css$/));
+requireAll(require.context('@modifiers', true, /\.css$/));


### PR DESCRIPTION
As of now, FC does not bundle the 'Modifiers' css on default. 

## Description
Makes it so.

## Motivation and Context
Properly supports the existing architecture of FC.

## How Has This Been Tested?
Create new Modifier, CSS rules get applied. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
