### PR TITLE
[WIP] PostCSS Plugin: postcss-responsive-font

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,3 +1,13 @@
 {
-  "extends": "stylelint-config-standard"
+	"extends": "stylelint-config-standard",
+	"rules": {
+		"property-no-unknown": [
+			true,
+			{
+				"ignoreProperties": [
+					"font-size-responsive"
+				]
+			}
+		]
+	}
 }

--- a/build/webpack/lib/postcss-plugins.js
+++ b/build/webpack/lib/postcss-plugins.js
@@ -11,6 +11,7 @@ const extend = require('postcss-extend');
 const discardEmpty = require('postcss-discard-empty');
 const removeRoot = require('postcss-remove-root');
 const mixins = require('postcss-mixins');
+const responsiveFont = require('postcss-responsive-font');
 
 // build
 const mqpacker = require('css-mqpacker');
@@ -58,6 +59,7 @@ const standard = [
       nesting: false
     }
   }),
+  responsiveFont(),
   extend(),
   discardEmpty(),
   removeRoot()

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "postcss-pipeline-webpack-plugin": "^3.0.0",
     "postcss-remove-root": "^0.0.2",
     "postcss-reporter": "^4.0.0",
+    "postcss-responsive-font": "^1.0.3",
     "pre-commit": "^1.2.2",
     "prismjs": "^1.6.0",
     "progress-bar-webpack-plugin": "^1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7295,6 +7295,12 @@ postcss-resolve-nested-selector@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
 
+postcss-responsive-font@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-responsive-font/-/postcss-responsive-font-1.0.3.tgz#8a0309f620d753d98fbb99d765f091698023ab0a"
+  dependencies:
+    postcss "^5.2.5"
+
 postcss-scss@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-0.4.1.tgz#ad771b81f0f72f5f4845d08aa60f93557653d54c"
@@ -7361,6 +7367,15 @@ postcss-zindex@^2.0.1:
 postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.13, postcss@^5.2.16, postcss@^5.2.4:
   version "5.2.17"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.17.tgz#cf4f597b864d65c8a492b2eabe9d706c879c388b"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
+postcss@^5.2.5:
+  version "5.2.18"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"


### PR DESCRIPTION
**This branch is a work in progress. I opened this PR so I can work on documenting the changes as I build them out. I will remove this comment and request reviewers when the code is ready for integration.**

## Description
This PR adds a new dev dependency to the project: [postcss-responsive-font](https://github.com/ccurtin/postcss-responsive-font). This PostCSS plugin allows us to create responsive font size rules in our stylesheets.

## Motivation and Context
We had begun an internal implementation of responsive font sizes and `postcss-responsive-font` came up during a team discussion. This is my attempt to keep that ball rolling.

## Example Usage
`.SomeTag { font-size-responsive: 1rem 2rem 20rem 80rem; }`

This would result in `.SomeTag` having a 1rem font-size at 20rem (viewport width) and 2rem at 80rem.

## How Has This Been Tested?
I was able to use the `font-size-responsive` property with no warnings, errors or issues. I tested with the `dev` command along with the various `build` commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

  