### PR TITLE
resolve SgStyleguide build warning

### DIFF
--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -72,7 +72,7 @@ export const SgStyleguide_Examples = (props) => {
         <Rhythm size="small">
           {
             examples.map((e) => (
-              <div key={e.slug} className={getLinkClassing}>
+              <div key={e.slug} className={getLinkClassing({})}>
                 <a href={`#${e.slug}`} value={e.name}>
                   {e.name}
                 </a>


### PR DESCRIPTION
The following warning is thrown when `npm run build` is used on any branch:

```
Warning: Invalid value for prop `className` on <div> tag. Either remove
it from the element, or pass a string or number value to keep it in the
DOM. For details, see https://fb.me/react-attribute-behavior
    in div
    in div
    in SgRhythm
    in div
    in SgRhythm
    in div
    in SgStyleguide_Examples
    in div
    in div
    in SgStyleguide
```

This PR contains a very small code change that resolves this warning with no side effects.

## How Has This Been Tested?
I ran the various builds commands with the tweak in place, and verified that the dev workflow wasn't impacted. Tested on Win10 with Node 8.9.3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

  