### PR TITLE
Fixes unconditioned example link classing

### DIFF
--- a/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/components/SgStyleguide/SgStyleguide.jsx
@@ -21,8 +21,10 @@ const getActiveTheme = (location) => {
 const getLinkClassing = (theme) => {
   if (theme.id === getActiveTheme(global.location)) {
     return 'SgStyleguide__theme-link SgStyleguide__theme-link--active';
+  } else if (theme.id) {
+    return 'SgStyleguide__theme-link';
   }
-  return 'SgStyleguide__theme-link';
+  return 'SgStyleguide__example-link';
 };
 
 export const SgStyleguide_Readme = (props) => (


### PR DESCRIPTION
## Description
Fixes #307 

## Motivation and Context
So FC component and tag examples links are stacking vs. aligned inline with no spacing.

## How Has This Been Tested?
Ran both dev and build, went to buttons and seen example links working as intended.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
