### PR TITLE
webpack-stats typo fix

### DIFF
--- a/build/webpack/lib/webpack-stats.js
+++ b/build/webpack/lib/webpack-stats.js
@@ -8,6 +8,6 @@ module.exports = {
   version: false,
   modules: false,
   colors: true,
-  error: true,
+  errors: true,
   errorDetails: true
 };


### PR DESCRIPTION
## Description
I was able to reproduce #302 using npm commands over yarn commands.

![Image of #302 error](https://ibin.co/w800/3nsadpgQjKeH.jpg)

## Motivation and Context
Allows npm commands to work again.
#302 

## How Has This Been Tested?
Prior to fixing typo, you would get the above mentioned error using npm install. 
Having fixed typo, npm install, run dev, run build all work again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
