### PR TITLE
Cleaning watch fix

### DIFF
--- a/build/webpack-watch-factory.js
+++ b/build/webpack-watch-factory.js
@@ -9,8 +9,8 @@ const gulp = require('gulp');
 const watch = require('gulp-watch');
 const { source } = require('./lib/path-helpers');
 
-module.exports = () => {
-	watch([ source('**/**') ], () => {
+module.exports = () => () => {
+	watch([ source('elements/components/**') ], () => {
 		gulp.start('webpack:watch:sequence');
 	}); 
 };

--- a/build/webpack-watch-factory.js
+++ b/build/webpack-watch-factory.js
@@ -10,7 +10,7 @@ const watch = require('gulp-watch');
 const { source } = require('./lib/path-helpers');
 
 module.exports = () => () => {
-	watch([ source('elements/components/**') ], () => {
+	watch([ source('**/**') ], () => {
 		gulp.start('webpack:watch:sequence');
 	}); 
 };


### PR DESCRIPTION
## Description
Quick fix for webpack-factory-watch that puts back the extra scope to watch task.

## Motivation and Context
Without this extra scope around the watch task, yarn dev hangs at color exports and never starts dev server.

## How Has This Been Tested?
npm run or yarn dev should finish
npm run or yarn watch still works


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
