### PR TITLE
Fixes #308

### DIFF
--- a/build/webpack/workflow/browser.js
+++ b/build/webpack/workflow/browser.js
@@ -89,7 +89,7 @@ module.exports = (
                       { removeUnusedNS: true },
                       { removeUselessDefs: true },
                       { removeUselessStrokeAndFill: true },
-                      { removeXMLNS: true },
+                      { removeXMLNS: false },
                       { removeXMLProcInst: true },
                       { sortAttrs: true },
                       { removeViewBox: false }
@@ -98,7 +98,7 @@ module.exports = (
                 }
               }
             ]
-          }
+          }         
         ]
       },
       plugins: [

--- a/build/webpack/workflow/browser.js
+++ b/build/webpack/workflow/browser.js
@@ -98,7 +98,7 @@ module.exports = (
                 }
               }
             ]
-          }         
+          }
         ]
       },
       plugins: [


### PR DESCRIPTION
## Description
SVG images being referenced via **img** or **picture** tag doesn't load the image, but instead references a XML version of said SVG file.

![SVG being referenced as a xml file](https://ibin.co/3nzpV4lOgpqW.jpg)

Turned out to be a SVGO plugin option in webpack/workflow/browser.js called removeXMLNS:
https://github.com/svg/svgo#what-it-can-do (see removeXMLNS)

#308

## Motivation and Context
With out removeXMLNS option set to false, inline SVG references will not render, but instead be severed up as a XML document.

## How Has This Been Tested?
- Downloaded this svg file: [Chainsaw](https://upload.wikimedia.org/wikipedia/commons/f/f6/Chainsaw_mono.svg) to **elements/image/assets/chainsaw.svg**
- In source/pages/index.js, imported the SVG file and Image tag:
`import Image from '@tags/Image/Image';
import Chainsaw from '@tags/Image/assets/chainsaw.svg';`
- Finally used it on a image tag.
`<Image src={Chainsaw} />`

Image loads and SVG sprites still work. **(see Icon example page to confirm sprites)**


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
