### PR TITLE
Toast Notifications CI Build Fix

### DIFF
--- a/build/webpack/webpack.config.build.ci.js
+++ b/build/webpack/webpack.config.build.ci.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 const { source, sourceAll } = require('../lib/path-helpers');
-const buildWorkflow = require('./workflow/build');
+const ciBuildWorkflow = require('./workflow/build.ci');
 
 const { entries } = require(source('fc-config')); // eslint-disable-line
 
@@ -19,7 +19,7 @@ const modify = (config) => {
 };
 
 
-module.exports = modify(merge(buildWorkflow, {
+module.exports = modify(merge(ciBuildWorkflow, {
   entry: sourceAll(entries.ci),
   plugins: [
     new webpack.DefinePlugin({

--- a/build/webpack/webpack.config.dll.ci.js
+++ b/build/webpack/webpack.config.dll.ci.js
@@ -5,13 +5,13 @@
 */
 
 const webpackMerge = require('webpack-merge');
-const dllWorkflow = require('./workflow/dll');
+const ciDllWorkflow = require('./workflow/dll.ci');
 const { source } = require('../lib/path-helpers');
 
 const { dlls } = require(source('fc-config')); // eslint-disable-line
 
 
-module.exports = webpackMerge(dllWorkflow, {
+module.exports = webpackMerge(ciDllWorkflow, {
   entry: {
     vendor: dlls.vendor
   }

--- a/build/webpack/webpack.config.dll.production.ci.js
+++ b/build/webpack/webpack.config.dll.production.ci.js
@@ -8,13 +8,13 @@
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 
-const dllProductionWorkflow = require('./workflow/dll.production');
+const ciProductionWorkflow = require('./workflow/dll.production.ci');
 const { source } = require('../lib/path-helpers');
 
 const { dlls } = require(source('fc-config')); // eslint-disable-line
 
 
-module.exports = webpackMerge(dllProductionWorkflow, {
+module.exports = webpackMerge(ciProductionWorkflow, {
   entry: {
     vendor: dlls.vendor
   },

--- a/build/webpack/webpack.config.production.ci.js
+++ b/build/webpack/webpack.config.production.ci.js
@@ -7,7 +7,7 @@ const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 const { source, sourceAll } = require('../lib/path-helpers');
-const productionWorkflow = require('./workflow/production');
+const ciProductionWorkflow = require('./workflow/production.ci');
 
 const { entries } = require(source('fc-config')); // eslint-disable-line
 
@@ -19,7 +19,7 @@ const modify = (config) => {
 };
 
 
-module.exports = modify(merge(productionWorkflow, {
+module.exports = modify(merge(ciProductionWorkflow, {
   entry: sourceAll(entries.ci),
   plugins: [
     new webpack.DefinePlugin({

--- a/build/webpack/webpack.config.production.js
+++ b/build/webpack/webpack.config.production.js
@@ -4,7 +4,6 @@
     - bundle static render bundle
 */
 
-const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 const { source, sourceAll } = require('../lib/path-helpers');

--- a/build/webpack/webpack.config.production.js
+++ b/build/webpack/webpack.config.production.js
@@ -4,6 +4,7 @@
     - bundle static render bundle
 */
 
+const webpack = require('webpack');
 const merge = require('webpack-merge');
 
 const { source, sourceAll } = require('../lib/path-helpers');
@@ -22,7 +23,7 @@ const modify = (config) => {
 
 module.exports = [
   merge(productionWorkflow, {
-    entry: sourceAll(entries.production)
+    entry: sourceAll(entries.production)  
   }),
   modify(merge(staticWorkflow, {
     entry: sourceAll(entries.static)

--- a/build/webpack/workflow/build.ci.js
+++ b/build/webpack/workflow/build.ci.js
@@ -1,0 +1,94 @@
+/*
+  Configures webpack to build all elements of the site.
+*/
+
+const webpackMerge = require('webpack-merge');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const PostCssPipelineWebpackPlugin = require('postcss-pipeline-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ProgressBarPlugin = require('progress-bar-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const OfflinePlugin = require('offline-plugin');
+const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+
+const skeletonConfig = require('../lib/skeleton-html-config.js');
+const browserWorkflow = require('./browser');
+const { source, baseUrl } = require('../../lib/path-helpers');
+const {
+  build: buildPipeline,
+  linting: lintingPipeline
+} = require('../lib/postcss-plugins.js');
+
+const { outputFormats } = require(source('fc-config')); // eslint-disable-line
+
+
+module.exports = (
+  webpackMerge(
+    browserWorkflow,
+    {
+      module: {
+        rules: [
+          {
+            test: /\.css$/,
+            enforce: 'pre',
+            loader: 'postcss-loader', // linting
+            options: {
+              plugins: lintingPipeline
+            }
+          },
+          {
+            test: /\.css$/,
+            use: ExtractTextPlugin.extract('css-loader?-minimize&sourceMap')
+          }
+        ]
+      },
+      plugins: [
+        new ProgressBarPlugin(),
+        new ExtractTextPlugin(`assets/${outputFormats.css}`),
+        new PostCssPipelineWebpackPlugin({
+          suffix: undefined,
+          pipeline: buildPipeline
+        }),
+        new FaviconsWebpackPlugin({
+          logo: source('favicon.png'),
+          prefix: `assets/favicons/${outputFormats.favIconPrefix}`,
+          persistentCache: false,
+          icons: {
+            android: false,
+            appleIcon: false,
+            appleStartup: false,
+            coast: false,
+            favicons: true,
+            firefox: false,
+            opengraph: false,
+            twitter: false,
+            yandex: false,
+            windows: false
+          }
+        }),
+        new CopyWebpackPlugin([{
+          from: source('static'),
+          to: 'assets/static'
+        }], {
+          ignore: ['README.md']
+        }),
+        new OfflinePlugin({
+          publicPath: baseUrl,
+          excludes: [
+            '**/_*',
+            '**/.*',
+            '**/*.map'
+          ],
+          ServiceWorker: {
+            output: 'assets/offline/sw.js'
+          },
+          AppCache: false
+        }),
+        new HtmlWebpackPlugin(Object.assign({}, skeletonConfig, {
+          filename: '_skeleton.html',
+          baseUrl
+        }))
+      ]
+    }
+  )
+);

--- a/build/webpack/workflow/build.js
+++ b/build/webpack/workflow/build.js
@@ -3,95 +3,19 @@
 */
 
 const webpackMerge = require('webpack-merge');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const PostCssPipelineWebpackPlugin = require('postcss-pipeline-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
-const OfflinePlugin = require('offline-plugin');
-const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 
-const skeletonConfig = require('../lib/skeleton-html-config.js');
 const browserWorkflow = require('./browser');
-const { source, baseUrl } = require('../../lib/path-helpers');
-const {
-  build: buildPipeline,
-  linting: lintingPipeline
-} = require('../lib/postcss-plugins.js');
-
-const { outputFormats } = require(source('fc-config')); // eslint-disable-line
-
+const ciBuildWorkflow = require('./build.ci');
 
 module.exports = (
   webpackMerge(
-    browserWorkflow,
+    ciBuildWorkflow,
     {
-      module: {
-        rules: [
-          {
-            test: /\.css$/,
-            enforce: 'pre',
-            loader: 'postcss-loader', // linting
-            options: {
-              plugins: lintingPipeline
-            }
-          },
-          {
-            test: /\.css$/,
-            use: ExtractTextPlugin.extract('css-loader?-minimize&sourceMap')
-          }
-        ]
-      },
       plugins: [
-        new ProgressBarPlugin(),
-        new ExtractTextPlugin(`assets/${outputFormats.css}`),
-        new PostCssPipelineWebpackPlugin({
-          suffix: undefined,
-          pipeline: buildPipeline
-        }),
         new WebpackNotifierPlugin({
           title: 'FC Build'
-        }),
-        new FaviconsWebpackPlugin({
-          logo: source('favicon.png'),
-          prefix: `assets/favicons/${outputFormats.favIconPrefix}`,
-          persistentCache: false,
-          icons: {
-            android: false,
-            appleIcon: false,
-            appleStartup: false,
-            coast: false,
-            favicons: true,
-            firefox: false,
-            opengraph: false,
-            twitter: false,
-            yandex: false,
-            windows: false
-          }
-        }),
-        new CopyWebpackPlugin([{
-          from: source('static'),
-          to: 'assets/static'
-        }], {
-          ignore: ['README.md']
-        }),
-        new OfflinePlugin({
-          publicPath: baseUrl,
-          excludes: [
-            '**/_*',
-            '**/.*',
-            '**/*.map'
-          ],
-          ServiceWorker: {
-            output: 'assets/offline/sw.js'
-          },
-          AppCache: false
-        }),
-        new HtmlWebpackPlugin(Object.assign({}, skeletonConfig, {
-          filename: '_skeleton.html',
-          baseUrl
-        }))
+        })
       ]
     }
   )

--- a/build/webpack/workflow/dll.ci.js
+++ b/build/webpack/workflow/dll.ci.js
@@ -1,0 +1,60 @@
+/*
+  Webpack configuration to precompile vendor
+  modules before the main bundle
+*/
+
+const webpack = require('webpack');
+const StatsPlugin = require('stats-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const stats = require('../lib/webpack-stats');
+const { source, dest } = require('../../lib/path-helpers');
+
+const { outputFormats } = require(source('fc-config')); // eslint-disable-line
+
+
+module.exports = {
+  devtool: 'inline-source-map',
+  resolve: {
+    extensions: ['.js', '.jsx']
+  },
+  node: {
+    fs: 'empty'
+  },
+  externals: {
+    jsdom: 'window',
+    cheerio: 'window',
+    'react/lib/ExecutionEnvironment': true,
+    'react/addons': true,
+    'react/lib/ReactContext': true
+  },
+  output: {
+    path: dest('assets/dlls'),
+    filename: outputFormats.dll,
+    library: '[name]_dll',
+    libraryTarget: 'umd'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(jsx|js)$/,
+        exclude: /node_modules\/(?!(get-own-enumerable-property-symbols|stringify-object)\/)/,
+        loader: 'babel-loader',
+        options: {
+          cacheDirectory: true
+        }
+      }
+    ]
+  },
+  plugins: [
+    new CleanWebpackPlugin(['assets/dlls'], { root: dest() }),
+    new webpack.DllPlugin({
+      path: dest('assets/dlls/[name]-manifest.json'),
+      name: '[name]_dll'
+    }),
+    new StatsPlugin('dll-stats.json', {
+      chunkModules: true,
+      exclude: [/node_modules/]
+    })
+  ],
+  stats
+};

--- a/build/webpack/workflow/dll.js
+++ b/build/webpack/workflow/dll.js
@@ -3,62 +3,18 @@
   modules before the main bundle
 */
 
-const webpack = require('webpack');
-const StatsPlugin = require('stats-webpack-plugin');
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const webpackMerge = require('webpack-merge');
 const WebpackNotifierPlugin = require('webpack-notifier');
-const stats = require('../lib/webpack-stats');
-const { source, dest } = require('../../lib/path-helpers');
 
-const { outputFormats } = require(source('fc-config')); // eslint-disable-line
+const ciConfig = require('./dll.ci');
 
-
-module.exports = {
-  devtool: 'inline-source-map',
-  resolve: {
-    extensions: ['.js', '.jsx']
-  },
-  node: {
-    fs: 'empty'
-  },
-  externals: {
-    jsdom: 'window',
-    cheerio: 'window',
-    'react/lib/ExecutionEnvironment': true,
-    'react/addons': true,
-    'react/lib/ReactContext': true
-  },
-  output: {
-    path: dest('assets/dlls'),
-    filename: outputFormats.dll,
-    library: '[name]_dll',
-    libraryTarget: 'umd'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(jsx|js)$/,
-        exclude: /node_modules\/(?!(get-own-enumerable-property-symbols|stringify-object)\/)/,
-        loader: 'babel-loader',
-        options: {
-          cacheDirectory: true
-        }
-      }
+module.exports = webpackMerge(
+  ciConfig,
+  {
+    plugins: [
+      new WebpackNotifierPlugin({
+        title: 'FC Dll'
+      })
     ]
-  },
-  plugins: [
-    new CleanWebpackPlugin(['assets/dlls'], { root: dest() }),
-    new webpack.DllPlugin({
-      path: dest('assets/dlls/[name]-manifest.json'),
-      name: '[name]_dll'
-    }),
-    new StatsPlugin('dll-stats.json', {
-      chunkModules: true,
-      exclude: [/node_modules/]
-    }),
-    new WebpackNotifierPlugin({
-      title: 'FC Dll'
-    })
-  ],
-  stats
-};
+  }
+);

--- a/build/webpack/workflow/dll.production.ci.js
+++ b/build/webpack/workflow/dll.production.ci.js
@@ -1,0 +1,32 @@
+/*
+  Webpack configuration to precompile
+  vendor modules before main bundle
+  in production mode
+*/
+
+const webpack = require('webpack');
+const webpackMerge = require('webpack-merge');
+
+const ciConfig = require('./dll.ci');
+
+
+module.exports = webpackMerge(
+  ciConfig,
+  {
+    devtool: 'source-map',
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      new webpack.LoaderOptionsPlugin({
+        minimize: true
+      }),
+      new webpack.optimize.UglifyJsPlugin({
+        sourceMap: true,
+        output: {
+          comments: false
+        }
+      })
+    ]
+  }
+);

--- a/build/webpack/workflow/production.ci.js
+++ b/build/webpack/workflow/production.ci.js
@@ -1,0 +1,33 @@
+/*
+  Configures the webpack production behavior
+*/
+
+const webpack = require('webpack');
+const webpackMerge = require('webpack-merge');
+const PostCssPipelineWebpackPlugin = require('postcss-pipeline-webpack-plugin');
+
+const { production: postcssPipeline } = require('../lib/postcss-plugins.js');
+const ciBuildWorkflow = require('./build.ci');
+
+
+module.exports = webpackMerge(
+  ciBuildWorkflow,
+  {
+    devtool: 'source-map', 
+    plugins: [
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      new PostCssPipelineWebpackPlugin({
+        suffix: undefined,
+        pipeline: postcssPipeline
+      }),
+      new webpack.optimize.UglifyJsPlugin({
+        sourceMap: true,
+        output: {
+          comments: false
+        }
+      })
+    ]
+  }
+);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('webpack:build', webpackBuild(buildConfig, true));
 gulp.task('webpack:build:ci', webpackBuild(buildCiConfig, true));
 gulp.task('webpack:production', webpackBuild(productionConfig, true));
 gulp.task('webpack:production:ci', webpackBuild(productionCiConfig, true));
-gulp.task('webpack:watch:build', webpackBuild(productionCiConfig, false));
+gulp.task('webpack:watch:build', webpackBuild(productionConfig, false));
 
 // watch is a minimal watcher for intergration
 // not requiring page rendering (only /assets)
@@ -76,21 +76,21 @@ gulp.task('build', series(
   'test'
 ));
 
-// builds a production ready set
-// of static assets and html
-gulp.task('production', series(
-  'clean:pre',
-  'webpack:production',
-  'static:render:production',
-  'clean:post'
-));
-
 // builds a minimal set of static
 // assets (only /assets folder, no html)
 // hint: this will be faster for integrators
 gulp.task('build:ci', series(
   'clean:pre',
   'webpack:build:ci',
+  'clean:post'
+));
+
+// builds a production ready set
+// of static assets and html
+gulp.task('production', series(
+  'clean:pre',
+  'webpack:production',
+  'static:render:production',
   'clean:post'
 ));
 


### PR DESCRIPTION
Fixes #320
All ci build types were designed to be passed to a workflow that makes use of the WebpackNotifierPlugin. This notification plugin triggers Jenkins to fail production and production:ci build.

## Description
I've made corresponding *.ci.js files for the following workflows: 

- build.js, 
- dll.js, 
- dll.production.js 
- production.js 

These new ci.js worflows now contain the majority of each build type's rules and plugins (minus the WebpackNotifierPlugin). I then went back into the original workflow files (build, dll, dll.production and production) and merge in these new corresponding ci workflows respectively.

Finally, after changing all ci builds to reference the new ci workflows, we now have all ci build types bypassing this toast notifications, while all non-ci builds retain toast notification.

## Motivation and Context
Fix production:ci builds from failing in Jenkins CI

## How Has This Been Tested?
I've ran every single build script in package.json confirming they all still work and only non-ci builds show toast notification.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
