### PR TITLE
Fix for SgExamples to continue working in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,6 @@
     "rand-token": "^0.3.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-element-to-jsx-string": "^13.1.0"
+    "react-element-to-string":"1.0.2"
   }
 }

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -22,7 +22,7 @@ module.exports.dlls = {
     'minimatch',
     'pretty',
     'prismjs',
-    'react-element-to-jsx-string',
+    'react-element-to-string',
     'rand-token'
   ],
 

--- a/source/styleguide/molecules/SgExample/SgExample.jsx
+++ b/source/styleguide/molecules/SgExample/SgExample.jsx
@@ -1,5 +1,5 @@
 import Dom from 'react-dom/server';
-import reactElementToString from 'react-element-to-jsx-string';
+import reactElementToString from 'react-element-to-string';
 import pretty from 'pretty';
 import Prism from 'prismjs';
 import 'prismjs/components/prism-jsx.min';


### PR DESCRIPTION
SgExamples or rather all atoms, molecules, organisms etc were not rendering in IE11 due to a bad plugin.

## Description
I've located a suitable replacement 'react-element-to-string' plugin that fixes the use of imports for IE11.

## Motivation and Context
Without this fix our styleguide will not work in IE10 or IE11.

## How Has This Been Tested?
Ran all builds, seems to be working while testing in both IE10 and IE11 on browser stack and local.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
