### PR TITLE
Bugfix | fileIndexData.js Bundling

### DIFF
--- a/source/styleguide/atoms/SgTableOfContents/fileIndexData.js
+++ b/source/styleguide/atoms/SgTableOfContents/fileIndexData.js
@@ -1,8 +1,8 @@
 export const pagesContext = require.context('@pages/', true, /^(?!.*\.test|.*\.example).*\.jsx$/);
-export const atomsContext = require.context('@atoms/', true, /^(?!.*\.test|.*\.example).*\.jsx$/);
-export const moleculesContext = require.context('@molecules/', true, /^(?!.*\.test|.*\.example).*\.jsx$/);
-export const organismsContext = require.context('@organisms/', true, /^(?!.*\.test|.*\.example).*\.jsx$/);
-export const templatesContext = require.context('@templates/', true, /^(?!.*\.test|.*\.example).*\.jsx$/);
+export const atomsContext = require.context('@atoms/', true, /^(?!.*\.test).*\.example.jsx$/);
+export const moleculesContext = require.context('@molecules/', true, /^(?!.*\.test).*\.example.jsx$/);
+export const organismsContext = require.context('@organisms/', true, /^(?!.*\.test).*\.example.jsx$/);
+export const templatesContext = require.context('@templates/', true, /^(?!.*\.test).*\.example.jsx$/);
 export const modifiersContext = require.context('@modifiers/', true, /^(?!.*\.test).*\.example.jsx$/);
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3930,10 +3930,6 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-own-enumerable-property-symbols@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
-
 get-proxy@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/get-proxy/-/get-proxy-1.1.0.tgz#894854491bc591b0f147d7ae570f5c678b7256eb"
@@ -5074,7 +5070,7 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
-is-obj@^1.0.0, is-obj@^1.0.1:
+is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
@@ -5104,7 +5100,7 @@ is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
-is-plain-object@2.0.4, is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
   dependencies:
@@ -5388,6 +5384,10 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
     jsonify "~0.0.0"
+
+json-stringify-pretty-compact@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.1.0.tgz#4fa5b898f61a287d64828691baa822a41f3ad5ab"
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
@@ -8198,12 +8198,12 @@ react-dom@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-element-to-jsx-string@^13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-13.1.0.tgz#a8dbd1a2aeec7ab58f380644f6b5e7e8c7c79c8f"
+react-element-to-string@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-element-to-string/-/react-element-to-string-1.0.2.tgz#0262f2ce0ffa8b518ea3597bc3a8dc26e0551a47"
   dependencies:
-    is-plain-object "2.0.4"
-    stringify-object "3.2.1"
+    indent-string "^2.1.0"
+    json-stringify-pretty-compact "^1.0.1"
 
 react-modal@^3.1.7:
   version "3.1.7"
@@ -9277,14 +9277,6 @@ string_decoder@~1.0.3:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
     safe-buffer "~5.1.0"
-
-stringify-object@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.1.tgz#2720c2eff940854c819f6ee252aaeb581f30624d"
-  dependencies:
-    get-own-enumerable-property-symbols "^2.0.1"
-    is-obj "^1.0.1"
-    is-regexp "^1.0.0"
 
 stringstream@~0.0.4:
   version "0.0.5"


### PR DESCRIPTION
Hello, all!

Let's have a conversation about how we bundle our 'elements' in Fuzzy.

## Revisit Modifiers Bundle Changes
When we added the new scaffolding and build process for Modifiers, we adjusted our 'build' process to generate HTML files based on whether or not these elements had an 'example'. This was because Modifiers, which don't require any markup, don't need a '.jsx' file to define itself as a React component.

We adjusted the parameters in 'build/lib/render-helpers.js' to look for the example files instead of <element>.jsx' files _in all elements_.
But Did We Reflect Those Changes In The Dev Process?
No. 

*SO NOW* we are adjusting the regex inside of fileIndexData to follow this same process for _all elements_, just like it does for 'build'. 

## Description
See above.

## Motivation and Context
Allows users the flexibility to define organisms (or any other element) with explicit '.jsx' files, _or_ through compositional 'example' files.

## How Has This Been Tested?
Run 'yarn dev, ' observe that the TableOfContents generates correctly and nothing explodes.

## Screenshots (if appropriate):
![yesss](https://user-images.githubusercontent.com/17711922/35652186-6df25b94-0697-11e8-9604-9b8f2f404319.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
