### PR TITLE
Resolve Missing "devNotes" Bug

### DIFF
--- a/source/styleguide/organisms/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/organisms/SgStyleguide/SgStyleguide.jsx
@@ -87,6 +87,7 @@ export const SgStyleguide_Examples = (props) => {
             key={e.slug}
             slug={e.slug}
             exampleName={e.name}
+            devNotes={e.devNotes}
             component={e.component}
             theme={e.theme}
             options={e.options}
@@ -101,6 +102,7 @@ SgStyleguide_Examples.propTypes = {
   examples: PropTypes.arrayOf(PropTypes.shape({
     name: PropTypes.string.isRequired,
     theme: PropTypes.string,
+    devNotes: PropTypes.string,
     options: PropTypes.object,
     component: PropTypes.element.isRequired
   }))


### PR DESCRIPTION
## Description
There was recently a slight oversight that resulted in our "devNotes" functionality being lost on styleguide examples. This branch contains a fix for that.

## How Has This Been Tested?
Build, production, test & dev commands have been run without issue.

To test the actual devNotes functionality in the styleguide, add a `devNotes` (string) prop to any example (along with `name` and `component`) and you'll see the button show up alongside the HTML & React buttons on the example.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
