### PR TITLE
Icon Gallery Styleguide Page

### DIFF
--- a/source/pages/styleguide/icons.jsx
+++ b/source/pages/styleguide/icons.jsx
@@ -1,0 +1,64 @@
+import Heading from '@atoms/Heading/Heading';
+import Rhythm from '@atoms/Rhythm/Rhythm';
+import SgPageWrapper from '@sg-atoms/SgPageWrapper/SgPageWrapper';
+import { SgIconSwatch, SgIconSwatch__search } from '@sg-molecules/SgIconSwatch/SgIconSwatch';
+import {
+  SgPageShell,
+  SgPageShell__header,
+  SgPageShell__navigation,
+  SgPageShell__main,
+  SgPageShell__body }
+  from '@sg-molecules/SgPageShell/SgPageShell';
+import SgGlobalHeader from '@sg-organisms/SgGlobalHeader/SgGlobalHeader';
+import SgNavigation from '@sg-organisms/SgNavigation/SgNavigation';
+
+const importIcons = (r) => r.keys().map(r);
+const projectIcons = importIcons(require.context('@elements/atoms/Icon/assets', false, /\.(svg)$/));
+const icons = [];
+
+Object.keys(projectIcons).map((i) => {
+  const fileName = projectIcons[i].split('/').slice(-1)[0].split('-');
+  fileName.pop();
+  const iconName = fileName.join('-');
+  icons.push({ name: iconName, path: projectIcons[i] });
+  return icons;
+});
+
+const page = () => (
+  <SgPageShell>
+    <SgPageShell__header>
+      <SgGlobalHeader />
+    </SgPageShell__header>
+    <SgPageShell__body>
+      <SgPageShell__navigation>
+        <SgNavigation />
+      </SgPageShell__navigation>
+      <SgPageShell__main>
+        <SgPageWrapper>
+          <Rhythm>
+            <Heading>Fuzzy Chainsaw Icons</Heading>
+            <p>
+              For each SVG file added to source/elements/atoms/Icon/assets, this page will list them here as a global view of all project icons.
+              The Icon example page better demonstraits icon style variations, while this page simply lists all project icons without variations.
+            </p>
+          </Rhythm>
+          <Rhythm>
+            <SgIconSwatch__search type="search" name="IconSearch" placeholder="Search for icon(s)" />
+          </Rhythm>
+          <Rhythm>
+            {
+              projectIcons ?
+              Object.keys(icons).map((i) => <SgIconSwatch icon={icons[i]} key={i} />)
+              : <div>No SVG files found in source/elements/atoms/Icon/assets/</div>
+            }
+          </Rhythm>
+        </SgPageWrapper>
+      </SgPageShell__main>
+    </SgPageShell__body>
+  </SgPageShell>
+);
+
+page.pageTitle = 'Style Guide | Colors';
+page.pageType = 'styleguide';
+
+export default page;

--- a/source/styleguide/molecules/SgIconSwatch/README.md
+++ b/source/styleguide/molecules/SgIconSwatch/README.md
@@ -1,0 +1,59 @@
+# Icon Swatch Generation
+
+## Post-CSS configuration:
+The configuration for automatically generating the Color Swatches is located in `./build/webpack/lib/postcss-plugins.js`.
+Fuzzy Chainsaw uses the postcss-export-vars NPM module to process the `colors.css` file and create the JSON data used by the React component.
+You can find the documentation for that plugin [here](https://github.com/nahody/postcss-export-vars).
+
+```
+// postcss-plugins.js
+
+const exportVars = require('postcss-export-vars');
+...
+
+const standard = [
+  exportVars({
+    file: './source/styleguide/components/SgColorSwatch/SgColorSwatch__variables',
+    type: 'json',
+    match: ['--color']
+  }),
+  mixins(),
+  nested(),
+...
+```
+Here is the configuration included in the current Fuzzy Chainsaw config files. 
+`file` refers to the destination, `type` the output format, and `match` is an array of prefixes targeted by the module.
+If you want to alter the prefixes associated with the project color variables, and you want them included inside the Color
+Swatches page, be sure to have your changes here in this configuration as well.
+
+## Color Naming Conventions
+Using this module does enforce naming conventions for project colors. 
+
+Prefix all project colors inside `./source/elements/variables/colors.css` with '--color'.
+
+In order for the plugin to not capture the color variables used by the Styleguide, prefix all Styleguide colors inside
+`./styleguide/variables/colors.css` with '--sg-color'.
+
+## WCAG 2.0 Standard Tests
+The SgColorSwatch measures contrast ratios against the 'AA', and 'AAA' standards of WCAG 2.0. 
+By default both of these tests are displayed inside the component in browser.
+
+The tests contrast '--color-text--primary' and '--color-text--secondary' against all variables prefixed with '--color'.
+
+The way that this component is build currently strictly enforces the '--color-text--primary' and '--color-text--secondary' values to be present.
+They are defaulted to '--color-black' and '--color-white'.
+
+Inside the react file the contrast tests target these two values here:
+```
+// SgColorSwatch.jsx
+
+...
+
+/* contrast tests */
+const contrastPrimary = getContrast(obj.hex, colorVars.colorTextPrimary);
+const contrastSecondary = getContrast(obj.hex, colorVars.colorTextSecondary);
+...
+```
+
+In order to add additional text color variables to be tested, a new `const contrastTertiary` would need to be created and passed
+into the React component as a prop where appropriate. 

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.Container.js
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.Container.js
@@ -1,0 +1,21 @@
+export default (el) => {
+  el.addEventListener('keyup', (e) => {
+    const query = e.target.value;
+    const icons = document.querySelectorAll('.SgIconSwatch');
+    let i = icons.length;
+    // unable to consolidate to single loop
+    if (query.length === 0) {
+      while (i--) {
+        icons[i].removeAttribute('style');
+      }
+    } else {
+      while (i--) {
+        if (!icons[i].dataset.iconName.match(query)) {
+          icons[i].style.display = 'none';
+        } else {
+          icons[i].removeAttribute('style');
+        }
+      }
+    }
+  });
+};

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
@@ -6,17 +6,21 @@
   width: 100%;
   text-align: center;
 
-  @media (--sg-medium) {
+  @media (--sg-medium-small) {
     margin: 0.5rem;
     max-width: calc(calc(100% / 2) - 1rem);
   }
 
-  @media (--sg-large) {
+  @media (--sg-medium) {
     max-width: calc(calc(100% / 3) - 1rem);
   }
 
-  @media (--sg-extra-large) {
+  @media (--sg-large) {
     max-width: calc(calc(100% / 4) - 1rem);
+  }
+
+  @media (--sg-extra-large) {
+    max-width: calc(calc(100% / 5) - 1rem);
   }
 
   & img {

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
@@ -6,13 +6,17 @@
   width: 100%;
   text-align: center;
 
-  @media (--sg-large) {
+  @media (--sg-medium) {
     margin: 0.5rem;
     max-width: calc(calc(100% / 2) - 1rem);
   }
 
-  @media (--sg-extra-large) {
+  @media (--sg-large) {
     max-width: calc(calc(100% / 3) - 1rem);
+  }
+
+  @media (--sg-extra-large) {
+    max-width: calc(calc(100% / 4) - 1rem);
   }
 
   & img {

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.css
@@ -1,0 +1,50 @@
+.SgIconSwatch {
+  border: 1px solid var(--sg-color-gray);
+  box-shadow: 1px 0.25rem 1rem -0.33rem color(var(--sg-color-black) alpha(15%));
+  display: inline-block;
+  padding: 1rem;
+  width: 100%;
+  text-align: center;
+
+  @media (--sg-large) {
+    margin: 0.5rem;
+    max-width: calc(calc(100% / 2) - 1rem);
+  }
+
+  @media (--sg-extra-large) {
+    max-width: calc(calc(100% / 3) - 1rem);
+  }
+
+  & img {
+    margin: 0.5rem;
+    height: 50px;
+  }
+
+  & pre {
+    border: 1px solid var(--sg-color-gray);
+    box-shadow: 1px 0.25rem 1rem -0.33rem color(var(--sg-color-black) alpha(15%));
+    margin-top: 0.5rem;
+    overflow: auto;
+    padding: 0.5rem;
+    text-align: left;
+  }
+
+  &__search {
+    border: none;
+    border-bottom: 1px solid var(--sg-color-gray);
+    margin: 1rem 0;
+    padding: 0.85rem;
+    width: 100%;
+
+    @media (--sg-large) {
+      margin: 1rem 0.5rem;
+      max-width: calc(calc(100% / 2) - 1rem);
+      width: calc(100% - 1rem);
+    }
+
+    @media (--sg-extra-large) {
+      margin: 1rem;
+      max-width: calc(calc(100% / 2) - 2rem);
+    }
+  }
+}

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.jsx
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.jsx
@@ -1,6 +1,3 @@
-import Prism from 'prismjs';
-import 'prismjs/components/prism-jsx.min';
-import 'prismjs/components/prism-json.min';
 import './SgIconSwatch.Container.js';
 
 export const SgIconSwatch = (props) => {
@@ -20,15 +17,6 @@ export const SgIconSwatch = (props) => {
       </div>
       <div className="SgIconSwatch__details">
         <strong>{icon.name}</strong>
-        <pre>
-          <code dangerouslySetInnerHTML={{
-            __html: Prism.highlight(
-              ['import Icon from \'./Icon\';\n<Icon name="', icon.name, '" />'].join(''),
-              Prism.languages.jsx
-            )
-          }}
-          />
-        </pre>
       </div>
     </div>
   );

--- a/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.jsx
+++ b/source/styleguide/molecules/SgIconSwatch/SgIconSwatch.jsx
@@ -1,0 +1,48 @@
+import Prism from 'prismjs';
+import 'prismjs/components/prism-jsx.min';
+import 'prismjs/components/prism-json.min';
+import './SgIconSwatch.Container.js';
+
+export const SgIconSwatch = (props) => {
+  const {
+    icon,
+    ...attrs
+  } = props;
+
+  const classStack = FcUtils.createClassStack([
+    'SgIconSwatch'
+  ]);
+
+  return (
+    <div className={classStack} data-icon-name={icon.name}>
+      <div className="SgIconSwatch__preview">
+        <img src={icon.path} {...attrs} alt="Icon preview" />
+      </div>
+      <div className="SgIconSwatch__details">
+        <strong>{icon.name}</strong>
+        <pre>
+          <code dangerouslySetInnerHTML={{
+            __html: Prism.highlight(
+              ['import Icon from \'./Icon\';\n<Icon name="', icon.name, '" />'].join(''),
+              Prism.languages.jsx
+            )
+          }}
+          />
+        </pre>
+      </div>
+    </div>
+  );
+};
+
+SgIconSwatch.propTypes = {
+  icon: PropTypes.object
+};
+
+export const SgIconSwatch__search = FcUtils.createBasicComponent({
+  name: 'SgIconSwatch__search',
+  defaultProps: {
+    tagName: 'input'
+  }
+});
+
+export default SgIconSwatch;

--- a/source/styleguide/styleguide.jsx
+++ b/source/styleguide/styleguide.jsx
@@ -9,6 +9,7 @@ import SgExpander from '@sg-atoms/SgExpander/SgExpander.Container';
 import SgNavigation from '@sg-organisms/SgNavigation/SgNavigation.Container';
 import SgPageShell from '@sg-molecules/SgPageShell/SgPageShell.Container';
 import SgTableOfContents from '@sg-molecules/SgTableOfContents/SgTableOfContents.Container';
+import SgIconSearch from '@sg-molecules/SgIconSwatch/SgIconSwatch.Container';
 import SgExample from '@sg-organisms/SgExample/SgExample.Container';
 import SgStyleguide from '@sg-organisms/SgStyleguide/SgStyleguide.Container';
 
@@ -18,7 +19,8 @@ const ui = {
   shell: document.querySelector('.SgPageShell'),
   styleguide: document.querySelector('.SgStyleguide'),
   toggles: Array.prototype.slice.call(document.querySelectorAll('.SgToggleButton')),
-  menu: document.querySelector('.SgTableOfContents')
+  menu: document.querySelector('.SgTableOfContents'),
+  iconSearch: document.querySelector('.SgIconSwatch__search')
 };
 
 const init = () => {
@@ -41,6 +43,10 @@ if (ui.menu) {
 
 if (ui.styleguide) {
   init();
+}
+
+if (ui.iconSearch) {
+  SgIconSearch(ui.iconSearch);
 }
 
 if (ui.shell) {


### PR DESCRIPTION
## Description
This is a quick pass at adding a Icon gallery page. Fixes #327 

Unlike the Atoms/Icon page; icon gallery page displays all project icons with no style variations from a single spot, and has a searching feature.

## Motivation and Context
Some project's Icons are crazy large, so having a single page that can give you a 30k foot view of all project icons with a searching feature can help with this issue.

## How Has This Been Tested?
This was a quick implementation, so please feel free to comment on and or dig into and change:
- Styles
- Search JS
- SgIconSwatch markup
- Or anything else you see fit

Run the following and confirm builds work. Confirm page looks as intended while running dev:
- run npm or yarn build
- run npm or yarn production
- run npm or yarn dev
- run npm or yarn watch

Thanks team!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
