### PR TITLE
SgExample Tweaks

### DIFF
--- a/source/styleguide/organisms/SgExample/SgExample.css
+++ b/source/styleguide/organisms/SgExample/SgExample.css
@@ -87,7 +87,7 @@
     margin-bottom: 1em;
 
     @media (width >= 540px) {
-      padding: 1em 3em 1em;
+      padding: 1em 3em;
     }
   }
 

--- a/source/styleguide/organisms/SgExample/SgExample.css
+++ b/source/styleguide/organisms/SgExample/SgExample.css
@@ -12,7 +12,7 @@
     & .SgHeading {
       font-weight: 500;
       line-height: 40px;
-      padding: 0 3rem;
+      padding: 0 2rem;
 
       @media (width >= 640px) {
         font-size: 1.5em;
@@ -29,7 +29,7 @@
     border-bottom: none;
     display: flex;
     font-size: 0.8em;
-    padding: 0 3rem 1rem;
+    padding: 0 2rem 1rem;
 
     @media (width >= 640px) {
       font-size: 1em;
@@ -83,10 +83,11 @@
   &__component {
     background-color: var(--sg-color-white);
     overflow: auto;
-    padding: 1em 3em;
+    padding: 1em 2em;
+    margin-bottom: 1em;
 
     @media (width >= 540px) {
-      padding: 1em 3em 2em;
+      padding: 1em 3em 1em;
     }
   }
 
@@ -98,22 +99,9 @@
   }
 
   &--dark-background {
-    background-color: var(--sg-color-background-dark);
-    color: var(--sg-color-white);
-    border-color: var(--sg-color-white);
-
     .SgExample__component {
       background-color: var(--sg-color-background-dark);
       color: initial;
-    }
-
-    .SgExample__tabs-item a {
-      color: var(--sg-color-white);
-
-      &:hover {
-        background-color: var(--sg-color-white);
-        color: var(--sg-color-black);
-      }
     }
 
     .SgExample__section {


### PR DESCRIPTION
## Description
This branch contains a couple small tweaks to the SgExample organism that @pgregorova requested a couple days ago:

1. Reduce the horizontal padding for small devices from 3em to 2em
2. Modify the dark background option to only affect the component, and not the entire example

## Motivation and Context
These changes are purely aesthetic and it's possible that we may decide as a team that they are not desirable or necessary. I would take no offense to that!

It's worth noting that I left the "dark-background" class on the SgExample tag, instead of moving it to the component itself. The reason for this is to keep the JSX tidy (utilize the FC class stack to apply it) and to allow for overrides to other child elements in the future without making non-CSS code changes.

## How Has This Been Tested?
This branch only contains a couple CSS tweaks so it should be very safe to merge into develop, should we choose to proceed with it.

## Screenshots (if appropriate):
[Old implementation](https://i.imgur.com/IklSpDv.png)
[New implementation](https://i.imgur.com/NCQZ048.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
