### PR TITLE
Missing rule for "noPadding" option within SgExample

### DIFF
--- a/source/styleguide/organisms/SgExample/SgExample.css
+++ b/source/styleguide/organisms/SgExample/SgExample.css
@@ -92,8 +92,8 @@
 
   &--full-width {
     .SgExample__component {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 

--- a/source/styleguide/organisms/SgExample/SgExample.jsx
+++ b/source/styleguide/organisms/SgExample/SgExample.jsx
@@ -150,6 +150,7 @@ export const SgExample = (props) => {
     'SgExample',
     options.fullWidth && 'SgExample--full-width',
     options.darkBackground && 'SgExample--dark-background',
+    options.noPadding && 'SgExample--full-width',
     `${theme}-theme-section`
   ]);
 


### PR DESCRIPTION
Noticed that 
```
options: {
   noPadding: true
  }
```

wasn't working. Most of the logic was already in place, just `SgExample--full-width` class wasn't being passed, so I added it in.