### PR TITLE
Rename SgIcon Asset (resolves #348)

### DIFF
--- a/source/styleguide/atoms/SgIcon/SgIconSet.js
+++ b/source/styleguide/atoms/SgIcon/SgIconSet.js
@@ -1,6 +1,6 @@
 const __svg__ = { // eslint-disable-line
   path: './assets/**/*.svg',
-  name: 'assets/svgs/iconset-[hash].svg'
+  name: 'assets/svgs/sg-iconset-[hash].svg'
 };
 
 ((options) => {


### PR DESCRIPTION
Issue and solution are both documented on #348, so I'll keep this brief.

With this one-line tweak, FC will output `sg-iconset-[hash].svg` and `iconset-[hash].svg` instead of 2x `iconset-[hash].svg` (where the only difference is the hash).

## How Has This Been Tested?
I have run the build, production and dev commands to ensure the project runs without warnings/errors and the newly-renamed icon set is loaded properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
