### PR TITLE
add enableNotifier option to fc-config.js

### DIFF
--- a/build/webpack/workflow/build.js
+++ b/build/webpack/workflow/build.js
@@ -5,18 +5,23 @@
 const webpackMerge = require('webpack-merge');
 const WebpackNotifierPlugin = require('webpack-notifier');
 
-const browserWorkflow = require('./browser');
 const ciBuildWorkflow = require('./build.ci');
+
+const { source } = require('../../lib/path-helpers');
+
+const { enableNotifier } = require(source('fc-config')); // eslint-disable-line
+
+const plugins = enableNotifier ? [
+  new WebpackNotifierPlugin({
+    title: 'FC Build'
+  })
+] : [];
 
 module.exports = (
   webpackMerge(
     ciBuildWorkflow,
     {
-      plugins: [
-        new WebpackNotifierPlugin({
-          title: 'FC Build'
-        })
-      ]
+      plugins
     }
   )
 );

--- a/build/webpack/workflow/dev.js
+++ b/build/webpack/workflow/dev.js
@@ -18,6 +18,14 @@ const { source, baseUrl } = require('../../lib/path-helpers');
 
 const { directories } = require(path.resolve(pkgpath.self(), 'package.json')); // eslint-disable-line
 
+const { enableNotifier } = require(source('fc-config')); // eslint-disable-line
+
+const notifierPlugin = enableNotifier ? [
+  new WebpackNotifierPlugin({
+    title: 'FC Dev'
+  })
+] : [];
+
 module.exports = (
   webpackMerge(
     browserWorkflow,
@@ -70,7 +78,7 @@ module.exports = (
           }
         ]
       },
-      plugins: [
+      plugins: notifierPlugin.concat([
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': JSON.stringify('dev')
         }),
@@ -80,16 +88,13 @@ module.exports = (
           baseUrl
         })),
         new webpack.HotModuleReplacementPlugin(),
-        new WebpackNotifierPlugin({
-          title: 'FC Dev'
-        }),
         new CopyWebpackPlugin([{
           from: source('static'),
           to: 'assets/static'
         }], {
           ignore: ['README.md']
         })
-      ],
+      ]),
       stats,
       devServer: {
         historyApiFallback: {

--- a/build/webpack/workflow/dll.js
+++ b/build/webpack/workflow/dll.js
@@ -8,13 +8,19 @@ const WebpackNotifierPlugin = require('webpack-notifier');
 
 const ciConfig = require('./dll.ci');
 
+const { source } = require('../../lib/path-helpers');
+
+const { enableNotifier } = require(source('fc-config')); // eslint-disable-line
+
+const plugins = enableNotifier ? [
+  new WebpackNotifierPlugin({
+    title: 'FC Dll'
+  })
+] : [];
+
 module.exports = webpackMerge(
   ciConfig,
   {
-    plugins: [
-      new WebpackNotifierPlugin({
-        title: 'FC Dll'
-      })
-    ]
+    plugins
   }
 );

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -84,3 +84,6 @@ module.exports.themes = [{
   id: 'generic',
   name: 'Generic'
 }];
+
+// true to enable webpack error & success notifications
+module.exports.enableNotifier = true;


### PR DESCRIPTION
Some folks love the notification toasts that we use on FC and some people don't. No one is right or wrong, and the best way to make everyone happy is to allow our users to toggle them as desired.

The code changes in this PR adds a new option to `/source/fc-config.js` called `enableNotifier` which is set to `true` by default. So out of the box, there is no change to the current behavior of FC.

If someone should want to disable these notifications, they can toggle that setting to false and the notifications will no longer appear.

I was going to build options, such as allowing users to only see failure notifications (and not warnings or successes), but the only type of notification that can be suppressed with [webpack-notifier](https://github.com/Turbo87/webpack-notifier) is warnings... so I kept things simple.

## How Has This Been Tested?
The three tasks that were modified (dll, build & dev) were thoroughly tested and no issues were found.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
