### PR TITLE
Replace PascalCase with Spaces on Style Guide Navigation

### DIFF
--- a/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
+++ b/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
@@ -6,12 +6,13 @@ import { themes } from '@source/fc-config';
 
 const SgFileIndex__ItemThemed = (props) => {
   const { url, content } = props.item;
+  const spacedContent = content.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
 
   const firstTheme = themes.length ? `?theme=${themes[0].id}` : '';
 
   return (
     <li>
-      <a className="SgFileIndex__name" href={`${url}${firstTheme}`}>{content}</a>
+      <a className="SgFileIndex__name" href={`${url}${firstTheme}`}>{spacedContent}</a>
       { themes.length > 1 &&
         <span className="SgFileIndex__links">
           ({ themes

--- a/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
+++ b/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
@@ -38,10 +38,11 @@ SgFileIndex__ItemThemed.propTypes = {
 
 const SgFileIndex__Item = (props) => {
   const { url, content } = props.item;
+  const spacedContent = content.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
 
   return (
     <li>
-      <a className="SgFileIndex__name" href={`${url}`}>{content}</a>
+      <a className="SgFileIndex__name" href={`${url}`}>{spacedContent}</a>
     </li>
   );
 };

--- a/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
+++ b/source/styleguide/molecules/SgFileIndex/SgFileIndex.jsx
@@ -3,16 +3,16 @@ import Rhythm from '@sg-atoms/SgRhythm/SgRhythm';
 import SgExpander from '@sg-atoms/SgExpander/SgExpander';
 import { themes } from '@source/fc-config';
 
+const pascalToSpaced = (text) => text.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
 
 const SgFileIndex__ItemThemed = (props) => {
   const { url, content } = props.item;
-  const spacedContent = content.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
 
   const firstTheme = themes.length ? `?theme=${themes[0].id}` : '';
 
   return (
     <li>
-      <a className="SgFileIndex__name" href={`${url}${firstTheme}`}>{spacedContent}</a>
+      <a className="SgFileIndex__name" href={`${url}${firstTheme}`}>{pascalToSpaced(content)}</a>
       { themes.length > 1 &&
         <span className="SgFileIndex__links">
           ({ themes
@@ -38,11 +38,10 @@ SgFileIndex__ItemThemed.propTypes = {
 
 const SgFileIndex__Item = (props) => {
   const { url, content } = props.item;
-  const spacedContent = content.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
 
   return (
     <li>
-      <a className="SgFileIndex__name" href={`${url}`}>{spacedContent}</a>
+      <a className="SgFileIndex__name" href={`${url}`}>{pascalToSpaced(content)}</a>
     </li>
   );
 };

--- a/source/styleguide/organisms/SgStyleguide/SgStyleguide.jsx
+++ b/source/styleguide/organisms/SgStyleguide/SgStyleguide.jsx
@@ -18,10 +18,12 @@ import {
 
 import { themes } from '@source/fc-config';
 
+const pascalToSpaced = (text) => text.replace(/([a-zA-Z])(?=[A-Z])/g, '$1 ');
+
 export const SgStyleguide_ReadmeHeading = (props) => (
   <div>
     <Heading level="h1" className="SgStyleguide__section--readme SgStyleguide__toggleTrigger">
-      {props.name}
+      {pascalToSpaced(props.name)}
       <SgExpander />
     </Heading>
     <div


### PR DESCRIPTION
This is a quick fix to turn `PascalCase` names into `Normal Spaced` names for items in the style guide navigation. This is a fix for #354.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
