### PR TITLE
Fixes table of contents navigation active link

### DIFF
--- a/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
+++ b/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
@@ -2,13 +2,15 @@ import select from 'dom-select';
 
 export default (el) => {
   const menuItems = select.all('.SgFileIndex__name', el);
-  const activeItem = menuItems.filter((item, index) => {
-    if (item.href.indexOf(window.location.pathname) !== -1) {
-      return index + 1;
+
+  const activeItem = menuItems.filter((item) => {
+    if (item.href.indexOf(window.location.pathname) >= 0) {
+      return item;
     }
     return false;
   });
-  if (activeItem.length) {
+
+  if (activeItem.length && activeItem.length === 1) {
     activeItem[0].classList.add('is-active');
   }
 };

--- a/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
+++ b/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
@@ -2,7 +2,12 @@ import select from 'dom-select';
 
 export default (el) => {
   const menuItems = select.all('.SgFileIndex__name', el);
-  const activeItem = menuItems.filter((item) => item.href.indexOf(window.location.pathname));
+  const activeItem = menuItems.filter((item, index) => {
+    if (item.href.indexOf(window.location.pathname) > 0) {
+      return index;
+    }
+    return false;
+  });
 
   if (activeItem) {
     activeItem[0].classList.add('is-active');

--- a/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
+++ b/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
@@ -3,7 +3,7 @@ import select from 'dom-select';
 export default (el) => {
   const menuItems = select.all('.SgFileIndex__name', el);
   const activeItem = menuItems.filter((item, index) => {
-    if (item.href.indexOf(window.location.pathname) >= 0) {
+    if (item.href.indexOf(window.location.pathname) !== -1) {
       return index + 1;
     }
     return false;

--- a/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
+++ b/source/styleguide/organisms/SgNavigation/SgNavigation.Container.js
@@ -3,13 +3,12 @@ import select from 'dom-select';
 export default (el) => {
   const menuItems = select.all('.SgFileIndex__name', el);
   const activeItem = menuItems.filter((item, index) => {
-    if (item.href.indexOf(window.location.pathname) > 0) {
-      return index;
+    if (item.href.indexOf(window.location.pathname) >= 0) {
+      return index + 1;
     }
     return false;
   });
-
-  if (activeItem) {
+  if (activeItem.length) {
     activeItem[0].classList.add('is-active');
   }
 };


### PR DESCRIPTION
## Description
Since making updates to the SgNavigation; how we gathered and located active link's index has changed. I've updated the code to be a bit more agnostic at how it gets an actual index now of links, vs trying to get a pointer to markup.

## Motivation and Context
Fixes active or rather current link state. Without this fix, all pages you visit will always list the first link in the navigation as active page.

## How Has This Been Tested?
While running a dev build, test the navigation links by clicking a few pages and confirm the active state follows you from page to page now.

Make sure:
- dev build
- full build
- production build

All are working still.
Thanks!


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
