### PR TITLE
Add Setting to Revert Scaffolding CSS to PascalCase (#365)

### DIFF
--- a/build/scaffold-factory.js
+++ b/build/scaffold-factory.js
@@ -11,6 +11,12 @@ const dopl = require('dopl');
 
 const { source } = require('./lib/path-helpers');
 
+const { codeStyle } = require(source('fc-config')); // eslint-disable-line
+
+
+const getCssName = (name) => (
+  codeStyle.pascalClassNames ? name : name.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase()
+);
 
 const scaffoldComponent = ({
   name,
@@ -39,7 +45,7 @@ module.exports = ({ src, dest }) => () => {
 
   return scaffoldComponent({
     name: argv.name,
-    cssName: argv.name.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase(),
+    cssName: getCssName(argv.name),
     src: path.resolve(__dirname, 'scaffolding', src),
     output: source('elements', dest, argv.name)
   });

--- a/source/fc-config.js
+++ b/source/fc-config.js
@@ -84,3 +84,8 @@ module.exports.themes = [{
   id: 'generic',
   name: 'Generic'
 }];
+
+// define code style options
+module.exports.codeStyle = {
+  pascalClassNames: false // set to true if scaffolding should use PascalCase class names
+};


### PR DESCRIPTION
This PR adds a new array of options to `fc-config.js` called `codeStyle`.

This array will be used to house code style options that are used in the build/scaffolding processes, starting with `pascalClassNames`.

`pascalClassNames` defaults to `false`, but when this is switched to `true` the FC scaffolding tasks will use PascalCase for the CSS class names on newly-generated atoms/molecules/organisms/modifiers.

This option will not change the baseline components and only affects new ones. The reason for this is to keep things simple and maintainable, while improving backwards-compatibility with components that may have been generated with PascalCase class names with older versions of FC.

See #365 for more information and context.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)